### PR TITLE
Added support for on-demand tables in the cloud.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Unpublished
+## [Unpublished]
 
 ### Added
 - Added latest Oracle Cloud Infrastructure regions and region codes: LIN, MTZ, VCP, BRS, UKB, JNB, SIN, MRS, ARN, AUH, MCT, WGA.
+- Cloud only: Added support for creating on-demand tables
+- On-Prem only: Added support for setting Durability in put/delete operations
+- Added support for returning row modification time in get operations
+
+### Changed
+- TableLimits now includes a CapacityMode field, to allow for specifying OnDemand. The default is Provisioned. This may affect existing code if the TableLimits struct was created without using named fields.
+- Internal logic now detects differences in server protocol version, and decrements its internal serial version to match. This is to maintain compatibility when a new driver is used with an old server.
 
 ## 1.2.2 - 2021-06-08
 

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -148,6 +148,10 @@ func createClient(cfg *Config) (*nosqldb.Client, error) {
 		return nil, err
 	}
 
+	// this will set the protocol serial version according to the connected server.
+	// ignore errors here, they may be expected.
+	client.VerifyConnection()
+
 	if interceptor != nil {
 		err = interceptor.OnSetupClient(client)
 		if err != nil {

--- a/nosqldb/bad_protocol_test.go
+++ b/nosqldb/bad_protocol_test.go
@@ -53,6 +53,9 @@ func (suite *BadProtocolTestSuite) SetupSuite() {
 	suite.bpTestClient, err = nosqldb.NewClient(suite.Client.Config)
 	suite.Require().NoErrorf(err, "failed to create a client, got error %v", err)
 
+	// this will set the serial protocol version. Ignore errors from it.
+	suite.bpTestClient.VerifyConnection()
+
 	// Disable retry handling.
 	suite.bpTestClient.RetryHandler = nil
 	suite.bpTestClient.AuthorizationProvider = suite.Client.AuthorizationProvider
@@ -580,6 +583,7 @@ func (suite *BadProtocolTestSuite) TestBadPutRequest() {
 		3,              // RequestTimeout: packed int
 		suite.tableLen, // TableName: String
 		1,              // ReturnRow: boolean
+		1,              // Durability: 1 byte (serialVersion > 2)
 		1,              // ExactMatch: boolean
 		1,              // IdentityCacheSize: packed int
 		suite.valueLen, // Record: MapValue
@@ -629,7 +633,10 @@ func (suite *BadProtocolTestSuite) TestBadPutRequest() {
 	}
 
 	// Invalid TTL value/unit.
-	off = seekPos(lengths, 9)
+	off = seekPos(lengths, 10)
+	if suite.bpTestClient.GetSerialVersion() < 3 {
+		off -= 1 // Durability
+	}
 	desc = "invalid TTL value"
 	copy(data, origData)
 	suite.wr.Reset()
@@ -718,6 +725,7 @@ func (suite *BadProtocolTestSuite) TestBadWriteMultipleRequest() {
 		3,              // RequestTimeout: packed int
 		suite.tableLen, // TableName: string
 		1,              // OperationNum: packed int
+		1,              // Durability: 1 byte (serialVersion > 2)
 		1,              // abortOnFail: boolean
 		0,              // Sub requests: the size does not matter for this test.
 	}
@@ -744,7 +752,10 @@ func (suite *BadProtocolTestSuite) TestBadWriteMultipleRequest() {
 	}
 
 	// Invalid opcode for sub requests.
-	off = seekPos(lengths, 6)
+	off = seekPos(lengths, 7)
+	if suite.bpTestClient.GetSerialVersion() < 3 {
+		off -= 1 // Durability
+	}
 	testOpCodes := []proto.OpCode{proto.OpCode(-1), proto.Get}
 	for _, v := range testOpCodes {
 		desc = fmt.Sprintf("invalid opcode %v", v)
@@ -772,6 +783,7 @@ func (suite *BadProtocolTestSuite) TestBadMultiDeleteRequest() {
 		1,              // OpCode: byte
 		3,              // RequestTimeout: packed int
 		suite.tableLen, // TableName: string
+		1,              // Durability: 1 byte (serialVersion > 2)
 		suite.keyLen,   // Key: MapValue
 		1,              // HasFieldRange: boolean
 		3,              // MaxWriteKB: packed int
@@ -788,7 +800,10 @@ func (suite *BadProtocolTestSuite) TestBadMultiDeleteRequest() {
 	suite.doBadProtoTest(req, data, desc, 0)
 
 	// Invalid MaxWriteKB.
-	off = seekPos(lengths, 6)
+	off = seekPos(lengths, 7)
+	if suite.bpTestClient.GetSerialVersion() < 3 {
+		off -= 1 // Durability
+	}
 	var tests []int
 	if test.IsOnPrem() {
 		// There is no limit on MaxWriteKB for the on-premise server.
@@ -807,7 +822,10 @@ func (suite *BadProtocolTestSuite) TestBadMultiDeleteRequest() {
 	}
 
 	// Invalid length of ContinuationKey.
-	off = seekPos(lengths, 7)
+	off = seekPos(lengths, 8)
+	if suite.bpTestClient.GetSerialVersion() < 3 {
+		off -= 1 // Durability
+	}
 	tests = []int{-2, 100}
 	for _, v := range tests {
 		desc = fmt.Sprintf("invalid length of ContinuationKey %v", v)
@@ -823,9 +841,14 @@ func (suite *BadProtocolTestSuite) TestBadTableRequest() {
 	newTable := "ABCD"
 	stmt := "create table if not exists " + newTable + " (id integer, primary key(id))"
 	stmtLen, _ := suite.wr.WriteString(&stmt)
+	limits := &nosqldb.TableLimits{
+		ReadUnits:  50,
+		WriteUnits: 50,
+		StorageGB:  2,
+	}
 	req := &nosqldb.TableRequest{
 		Statement:   stmt,
-		TableLimits: &nosqldb.TableLimits{50, 50, 5},
+		TableLimits: limits,
 	}
 
 	var desc string
@@ -839,6 +862,7 @@ func (suite *BadProtocolTestSuite) TestBadTableRequest() {
 		4,       // ReadKB: int
 		4,       // WriteKB: int
 		4,       // StorageGB: int
+		1,       // LimitMode: byte (serialVersion > 2)
 		1,       // HasTableName: boolean
 	}
 

--- a/nosqldb/data_ops_test.go
+++ b/nosqldb/data_ops_test.go
@@ -941,9 +941,9 @@ func (suite *DataOpsTestSuite) TestNonNumericDataTypes() {
 	// int/int64 values are valid for TIMESTAMP data type starting with NoSQL
 	// Server 20.2.14 on-premise release and Cloud Simulator 1.3.2 release.
 	//if suite.IsOnPrem() && suite.Version >= "20.2.14" || suite.IsCloudSim() && suite.Version >= "1.3.2" {
-		tsTest.validValues = append(tsTest.validValues, []types.FieldValue{intVal, int64Val}...)
+	tsTest.validValues = append(tsTest.validValues, []types.FieldValue{intVal, int64Val}...)
 	//} else {
-		//tsTest.invalidValues = append(tsTest.invalidValues, []types.FieldValue{intVal, int64Val}...)
+	//tsTest.invalidValues = append(tsTest.invalidValues, []types.FieldValue{intVal, int64Val}...)
 	//}
 
 	testCases = append(testCases, tsTest)

--- a/nosqldb/internal/proto/protocol.go
+++ b/nosqldb/internal/proto/protocol.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	// SerialVersion represents the protocol version used to serialize requests
-	// and deserialize results between client and server.
-	SerialVersion int16 = 2
+	// DefaultSerialVersion represents the protocol version used to serialize requests
+	// and deserialize results between client and server. The client may reduce this
+	// value when connected to older servers.
+	DefaultSerialVersion int16 = 3
 
 	// QueryVersion represents the version used for query requests.
 	QueryVersion int16 = 3
@@ -224,6 +225,14 @@ type Writer interface {
 
 	// WriteConsistency writes a Consistency value.
 	WriteConsistency(c types.Consistency) (int, error)
+
+	// WriteDurability writes a Durability value, if the
+	// protocol version supports it.
+	WriteDurability(c types.Durability, serialVersion int16) (int, error)
+
+	// WriteCapacityMode writes a CapacityMode value, if the
+	// protocol version supports it.
+	WriteCapacityMode(lm types.CapacityMode, serialVersion int16) (int, error)
 
 	// WriteTTL writes a TimeToLive value.
 	WriteTTL(ttl *types.TimeToLive) (int, error)

--- a/nosqldb/nosqlerr/errors.go
+++ b/nosqldb/nosqlerr/errors.go
@@ -258,6 +258,17 @@ const (
 	// OperationNotSupported error represents the operation attempted is not supported.
 	// This may be related to on-premise vs cloud service configurations.
 	OperationNotSupported // 21
+
+	// EtagMismatch is used only by the cloud REST service.
+	EtagMismatch // 22
+
+	// CannotCancelWorkRequest is used only by the cloud REST service.
+	CannotCancelWorkRequest // 23
+
+	// UnsupportedProtocol error indicates the server does not support the
+	// given driver protocol version. The driver should decrement its internal
+	// protocol version (and accompanying logic) and try again.
+	UnsupportedProtocol // 24
 )
 
 const (

--- a/nosqldb/result.go
+++ b/nosqldb/result.go
@@ -109,6 +109,10 @@ type GetResult struct {
 	// which means the returned Value is non-nil.
 	ExpirationTime time.Time `json:"expirationTime"`
 
+	// ModificationTime represents the modification time of an existing row.
+	// Its value is in milliseconds since January 1 1970.
+	ModificationTime int64 `json:"modificationTime"`
+
 	DelayInfo
 }
 
@@ -435,6 +439,10 @@ type WriteResult struct {
 
 	// ExistingValue represents the Value of an existing row.
 	ExistingValue *types.MapValue `json:"existingValue"`
+
+	// ExistingModificationTime represents the modification time of an existing row.
+	// Its value is in milliseconds since January 1 1970.
+	ExistingModificationTime int64 `json:"existingModificationTime"`
 }
 
 // String returns a JSON string representation of the WriteResult.

--- a/nosqldb/table_ops_test.go
+++ b/nosqldb/table_ops_test.go
@@ -88,9 +88,12 @@ func (suite *TableOpsTestSuite) TestTableLimits() {
 		testCases = []*tableRequestTestCase{
 			{
 				req: &nosqldb.TableRequest{
-					TableName:   tableName,
-					TableLimits: &nosqldb.TableLimits{5, 5, 2},
-					Timeout:     test.OkTimeout,
+					TableName: tableName,
+					TableLimits: &nosqldb.TableLimits{
+						ReadUnits:  5,
+						WriteUnits: 5,
+						StorageGB:  2},
+					Timeout: test.OkTimeout,
 				},
 				expErr: nosqlerr.OperationNotSupported,
 			},
@@ -101,16 +104,22 @@ func (suite *TableOpsTestSuite) TestTableLimits() {
 			// Positive test cases.
 			{
 				req: &nosqldb.TableRequest{
-					TableName:   tableName,
-					TableLimits: &nosqldb.TableLimits{5, 5, 2},
-					Timeout:     test.OkTimeout,
+					TableName: tableName,
+					TableLimits: &nosqldb.TableLimits{
+						ReadUnits:  5,
+						WriteUnits: 5,
+						StorageGB:  2},
+					Timeout: test.OkTimeout,
 				},
 			},
 			{
 				req: &nosqldb.TableRequest{
-					TableName:   tableName,
-					TableLimits: &nosqldb.TableLimits{6, 4, 1},
-					Timeout:     test.OkTimeout,
+					TableName: tableName,
+					TableLimits: &nosqldb.TableLimits{
+						ReadUnits:  6,
+						WriteUnits: 4,
+						StorageGB:  1},
+					Timeout: test.OkTimeout,
 				},
 			},
 			// Negative test cases.


### PR DESCRIPTION
- Cloud only: Added support for creating on-demand tables
- On-Prem only: Added support for setting Durability in put/delete operations
- Added support for returning row modification time in get operations

- TableLimits now includes a CapacityMode field, to allow for specifying OnDemand. The default is Provisioned. This may affect existing code if the TableLimits struct was created without using named fields.
- Internal logic now detects differences in server protocol version, and decrements its internal serial version to match. This is to maintain compatibility when a new driver is used with an old server.