### PR TITLE
enhancements to auth with instance or resource principals

### DIFF
--- a/nosqldb/auth/iam/configuration.go
+++ b/nosqldb/auth/iam/configuration.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/oracle/nosql-go-sdk/nosqldb/internal/sdkutil"
 )
@@ -58,6 +59,11 @@ func NewRawConfigurationProvider(tenancy, user, region, fingerprint, privateKey 
 
 func (p rawConfigurationProvider) PrivateRSAKey() (key *rsa.PrivateKey, err error) {
 	return PrivateKeyFromBytes([]byte(p.privateKey), p.privateKeyPassphrase)
+}
+
+func (p rawConfigurationProvider) ExpirationTime() time.Time {
+	// raw configs don't expire
+	return time.Now().Add(24 * time.Hour)
 }
 
 func (p rawConfigurationProvider) KeyID() (keyID string, err error) {
@@ -299,6 +305,11 @@ func (p fileConfigurationProvider) KeyFingerprint() (value string, err error) {
 	}
 	value, err = presentOrError(info.Fingerprint, hasFingerprint, info.PresentConfiguration, "fingerprint")
 	return
+}
+
+func (p fileConfigurationProvider) ExpirationTime() time.Time {
+	// file configs don't expire
+	return time.Now().Add(24 * time.Hour)
 }
 
 func (p fileConfigurationProvider) KeyID() (keyID string, err error) {

--- a/nosqldb/auth/iam/iam.go
+++ b/nosqldb/auth/iam/iam.go
@@ -308,7 +308,14 @@ func (p *SignatureProvider) SignHTTPRequest(req *http.Request) error {
 		return err
 	}
 	p.signature = req.Header.Get(requestHeaderAuthorization)
+
 	p.signatureExpiresAt = now.Add(p.expiryInterval)
+
+	// need to use min(expiryInterval, tokenExpiration)
+	exp := p.signer.ExpirationTime()
+	if p.signatureExpiresAt.After(exp) {
+		p.signatureExpiresAt = exp
+	}
 
 	return nil
 }

--- a/nosqldb/auth/iam/instance_principal_key_provider.go
+++ b/nosqldb/auth/iam/instance_principal_key_provider.go
@@ -138,6 +138,10 @@ func (p *instancePrincipalKeyProvider) KeyID() (string, error) {
 	return fmt.Sprintf("ST$%s", securityToken), nil
 }
 
+func (p *instancePrincipalKeyProvider) ExpirationTime() time.Time {
+	return p.FederationClient.ExpirationTime()
+}
+
 func (p *instancePrincipalKeyProvider) TenancyOCID() (string, error) {
 	return p.TenancyID, nil
 }
@@ -166,6 +170,10 @@ func (p *instancePrincipalConfigurationProvider) PrivateRSAKey() (*rsa.PrivateKe
 
 func (p *instancePrincipalConfigurationProvider) KeyID() (string, error) {
 	return p.keyProvider.KeyID()
+}
+
+func (p *instancePrincipalConfigurationProvider) ExpirationTime() time.Time {
+	return p.keyProvider.ExpirationTime()
 }
 
 func (p *instancePrincipalConfigurationProvider) TenancyOCID() (string, error) {

--- a/nosqldb/auth/iam/jwt.go
+++ b/nosqldb/auth/iam/jwt.go
@@ -18,12 +18,16 @@ type jwtToken struct {
 	payload map[string]interface{}
 }
 
-const bufferTimeBeforeTokenExpiration = 5 * time.Minute
+// Return token expiry
+func (t *jwtToken) expirationTime() time.Time {
+	return time.Unix(int64(t.payload["exp"].(float64)), 0)
+}
 
+// NOTE: There are certain cases where the security token returned from Identity may
+// have a very short expiry (less than 5 minutes), and it's still valid. So this
+// expiration check must check up to the current second
 func (t *jwtToken) expired() bool {
-	exp := int64(t.payload["exp"].(float64))
-	expired := exp <= time.Now().Unix()+int64(bufferTimeBeforeTokenExpiration.Seconds())
-	return expired
+	return time.Now().After(t.expirationTime())
 }
 
 func parseJwt(tokenString string) (*jwtToken, error) {

--- a/nosqldb/auth/iam/resouce_principal_key_provider.go
+++ b/nosqldb/auth/iam/resouce_principal_key_provider.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"time"
 )
 
 const (
@@ -148,6 +149,10 @@ func (p *resourcePrincipalKeyProvider) KeyID() (string, error) {
 		return "", fmt.Errorf("failed to get security token: %s", err.Error())
 	}
 	return fmt.Sprintf("ST$%s", securityToken), nil
+}
+
+func (p *resourcePrincipalKeyProvider) ExpirationTime() time.Time {
+	return p.FederationClient.ExpirationTime()
 }
 
 func (p *resourcePrincipalKeyProvider) Region() (string, error) {

--- a/nosqldb/client.go
+++ b/nosqldb/client.go
@@ -1145,11 +1145,19 @@ func (c *Client) warmupClientAuth() {
 	// Create a dummy http request and pass it to the signing logic.
 	// this will initialize the IAM auth underneath.
 	// Don't return any errors - this is a best-effort attempt.
-	httpReq, err := httputil.NewPostRequest("https://nosql.oracle.com", []byte{})
+	c.logger.Fine("Warming up auth...");
+	httpReq, err := httputil.NewPostRequest(c.requestURL, []byte{})
 	if err != nil {
+		c.logger.Fine("Got error creating warmup request: %v", err)
 		return
 	}
-	c.signHTTPRequest(httpReq)
+	httpReq.Header.Add("Host", c.serverHost)
+	err = c.signHTTPRequest(httpReq)
+	if err != nil {
+		c.logger.Fine("Got error signing warmup request: %v", err)
+		return
+	}
+	c.logger.Fine("Auth warmed up successfully")
 }
 
 func (c *Client) tableNeedsRefresh(tableName string) bool {

--- a/nosqldb/client.go
+++ b/nosqldb/client.go
@@ -151,6 +151,8 @@ func NewClient(cfg Config) (*Client, error) {
 
 	c.oneTimeMessages = make(map[string]struct{})
 
+	c.warmupClientAuth()
+
 	return c, nil
 }
 
@@ -1136,6 +1138,18 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 
 		return result, nil
 	}
+}
+
+
+func (c *Client) warmupClientAuth() {
+	// Create a dummy http request and pass it to the signing logic.
+	// this will initialize the IAM auth underneath.
+	// Don't return any errors - this is a best-effort attempt.
+	httpReq, err := httputil.NewPostRequest("https://nosql.oracle.com", []byte{})
+	if err != nil {
+		return
+	}
+	c.signHTTPRequest(httpReq)
 }
 
 func (c *Client) tableNeedsRefresh(tableName string) bool {


### PR DESCRIPTION
The following enhancements are made for both instance and resource principal usage:
- Use the minimum of the signature expiration and the underlying token expiration to determine if a signature needs to be recalculated. This is to ensure no auth errors if a token is issued that has a very short (less than 5 minutes) expiration.
- Warm up the signature provider (get a new token) on handle creation, to avoid added latency on first request