### PR TITLE
Fix for slices version incompatibilities

### DIFF
--- a/nosqldb/internal/proto/binary/struct_reader.go
+++ b/nosqldb/internal/proto/binary/struct_reader.go
@@ -50,11 +50,11 @@ func (sr *StructReader) DiscardMap() error {
 	}
 	for i := 0; i < size; i++ {
 		// field name
-		key, err := sr.reader.ReadString()
+		_, err := sr.reader.ReadString()
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(os.Stdout, "Disacrding field '%s'\n", *key)
+		//fmt.Fprintf(os.Stdout, "Discarding field '%s'\n", *key)
 		err = sr.ReadFieldValue(reflect.Value{})
 		if err != nil {
 			return err
@@ -121,7 +121,7 @@ func (sr *StructReader) ReadMap(v reflect.Value) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(os.Stdout, "Handling field '%s'\n", *key)
+		//fmt.Fprintf(os.Stdout, "Handling field '%s'\n", *key)
 
 		// Figure out field corresponding to key.
 		var subv reflect.Value

--- a/nosqldb/internal/proto/binary/struct_writer.go
+++ b/nosqldb/internal/proto/binary/struct_writer.go
@@ -16,7 +16,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"reflect"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -524,8 +523,8 @@ func (me mapEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 		}
 		sv[i].v = mi.Value()
 	}
-	slices.SortFunc(sv, func(i, j reflectWithString) int {
-		return strings.Compare(i.ks, j.ks)
+	sort.Slice(sv, func(i, j int) bool {
+		return sv[i].ks < sv[j].ks
 	})
 
 	if _, err := e.writeOneByte(byte(types.Map)); err != nil {


### PR DESCRIPTION
Removed use of "slices" to prevent go version incompatibilities.
The "slices" package was external up to go 1.22, where it was brought into the core. To avoid needing
version-specific compilation, this fix just removes the call that used slices and instead just uses the sort package.
Also removed two errant debug messages in struct reading.