### PR TITLE
Preparing for 1.4.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,29 +3,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Unreleased
+## 1.4.7 - 2024-08-13
 
 ### Changed
 - Internal: updated tests for upcoming new "return existing row" semantics
 
 ## 1.4.6 - 2024-08-12
 
-### Fixed
-- Fixed go incompatibility with pre-1.21 go version, stemming from 1.4.4 and 1.4.5 releases.
-
-## 1.4.5 - 2024-08-12
-
-### Fixed
-- Fixed a go version incompatibility issue with the "slices" module that was introduced in 1.4.4 release.
-
-
-## 1.4.4 - 2024-08-01
-
 ### Added
 - Native Structs: Added capability to use native structs in get/put/query. See [Native Structs](https://github.com/oracle/nosql-go-sdk/blob/main/native_structs.md) for details.
 
 ### Changed
 - Now requires Go 1.18 or higher
+
+note: releases 1.4.4 and 1.4.5 were removed due to version incompatibilities.
 
 
 ## 1.4.3 - 2024-07-01

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ and to [the Oracle NoSQL Cloud Simulator](https://www.oracle.com/downloads/cloud
 This project is open source and maintained by Oracle Corp.
 
 ## Prerequisites
-- Go 1.16 or later
-  - Download a [Go](https://golang.org/dl/) 1.16+ binary release suitable for your system.
+- Go 1.18 or later
+  - Download a [Go](https://golang.org/dl/) 1.18+ binary release suitable for your system.
   - Install on your system following the [installation instructions](https://golang.org/doc/install).
-  - Go for Oracle Linux 7 can be installed via `yum`: [Go Packages for Oracle Linux](http://yum.oracle.com/oracle-linux-golang.html).
+  - Go for Oracle Linux can be installed via `yum`: [Go Packages for Oracle Linux](http://yum.oracle.com/oracle-linux-golang.html).
   - Add the directory that contains the `go` executable into your system PATH, for example:
     ```bash
     export PATH=/usr/local/go/bin:$PATH

--- a/doc/connect.md
+++ b/doc/connect.md
@@ -8,7 +8,7 @@ Database Go SDK. There are several supported environments:
 ## Prerequisites
 
 The Go SDK requires:
-* Go 1.16 or later
+* Go 1.18 or later
 * For the Oracle NoSQL Cloud Service
   - An Oracle Cloud Infrastructure account
   - A user created in that account, in a group with a policy that grants the desired permissions.


### PR DESCRIPTION
Updated docs to specify go version 1.18 or higher is required.