### PR TITLE
Use OCI region metadata if needed ; allow auto-creation of region info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Unreleased
+
+## Added
+- Cloud only: Added the capability to determine region metadata from OCI configuration.
+  This enables using new regions that may not have been added to the SDK code yet, without
+  having to specify a full NoSQL endpoint parameter.
+  See [Adding Regions](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdk_adding_new_region_endpoints.htm) for more information.
+
+## Changed
+- Cloud only: Internal OCI `Region` definitions have been updated to be consistent. Some previous
+  shorthand `Region`s have been removed, for example `RegionPHX` and `RegionIAD`. This should not affect any
+  external usage, as the `Region` definitions are intended for internal logic only. Interaction
+  with the NoSQL APIs should always use region identifier strings, such as `us-phoenix-1`, or
+  full endpoint strings, such as `nosql.us-phoenix-1.oci.oraclecloud.com`.
+
 ## 1.4.7 - 2024-08-13
 
 ### Changed

--- a/nosqldb/auth/iam/iam.go
+++ b/nosqldb/auth/iam/iam.go
@@ -64,19 +64,19 @@ type SignatureProvider struct {
 
 // NewSignatureProvider creates a signature provider using the "DEFAULT"
 // profile specified in the default OCI configuration file ~/.oci/config.
-// See https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm
-// for details of the configuration file's contents and format.
+// See [SDK Configuration File] for details of the configuration file's contents and format.
 //
 // This signature provider uses the tenancyOCID that is the "tenancy" field
 // specified in the configuration file as compartmentID.
+//
+// [SDK Configuration File]: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm
 func NewSignatureProvider() (*SignatureProvider, error) {
 	return NewSignatureProviderFromFile("~/.oci/config", "", "", "")
 }
 
 // NewSignatureProviderFromFile creates a signature provider using the ociProfile
 // specified in the OCI configuration file configFilePath.
-// See https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm
-// for details of the configuration file's contents and format.
+// See [SDK Configuration File] for details of the configuration file's contents and format.
 //
 // ociProfile is optional; if empty, "DEFAULT" will be used.
 //
@@ -89,6 +89,8 @@ func NewSignatureProvider() (*SignatureProvider, error) {
 // the root compartment as compartmentID.
 // For example, if using rootCompartment.compartmentA.compartmentB, the
 // compartmentID should be set to compartmentA.compartmentB.
+//
+// [SDK Configuration File]: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm
 func NewSignatureProviderFromFile(configFilePath, ociProfile, privateKeyPassphrase, compartmentID string) (*SignatureProvider, error) {
 
 	// default to OCI "DEFAULT" if none given
@@ -248,7 +250,7 @@ func NewSignatureProviderWithInstancePrincipalDelegationFromFile(compartmentID s
 // root compartment of the user's tenancy.
 //
 // [SDK Configuration File]: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm
-// Session Token-Based Authentication]: https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdk_authentication_methods.htm#sdk_authentication_methods_session_token
+// [Session Token-Based Authentication]: https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdk_authentication_methods.htm#sdk_authentication_methods_session_token
 // [Token-based Authentication for the CLI]: https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm
 func NewSessionTokenSignatureProvider() (*SignatureProvider, error) {
 	return NewSessionTokenSignatureProviderFromFile("~/.oci/config", "DEFAULT", "")
@@ -272,7 +274,7 @@ func NewSessionTokenSignatureProvider() (*SignatureProvider, error) {
 // root compartment of the user's tenancy.
 //
 // [SDK Configuration File]: https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm
-// Session Token-Based Authentication]: https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdk_authentication_methods.htm#sdk_authentication_methods_session_token
+// [Session Token-Based Authentication]: https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdk_authentication_methods.htm#sdk_authentication_methods_session_token
 // [Token-based Authentication for the CLI]: https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm
 func NewSessionTokenSignatureProviderFromFile(configFilePath, ociProfile, privateKeyPassphrase string) (*SignatureProvider, error) {
 	// default to OCI "DEFAULT" if none given

--- a/nosqldb/auth/iam/instance_principal_key_provider.go
+++ b/nosqldb/auth/iam/instance_principal_key_provider.go
@@ -107,6 +107,8 @@ func getRegionForFederationClient(httpClient httputil.RequestExecutor, url strin
 		}
 		return
 	}
+	// enable IMDS, in case we don't have this region hardcoded yet
+	common.EnableInstanceMetadataServiceLookup()
 	return common.StringToRegion(body.String())
 }
 

--- a/nosqldb/auth/iam/instance_principal_key_provider_test.go
+++ b/nosqldb/auth/iam/instance_principal_key_provider_test.go
@@ -25,7 +25,7 @@ func TestInstancePrincipalKeyProvider_getRegionForFederationClient(t *testing.T)
 	actualRegion, err := getRegionForFederationClient(&http.Client{}, regionServer.URL)
 
 	assert.NoError(t, err)
-	assert.Equal(t, common.RegionPHX, actualRegion)
+	assert.Equal(t, common.RegionUsPhoenix1, actualRegion)
 }
 
 func TestInstancePrincipalKeyProvider_getRegionForFederationClientNotFound(t *testing.T) {

--- a/nosqldb/common/region.go
+++ b/nosqldb/common/region.go
@@ -9,467 +9,55 @@
 package common
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/user"
+	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Region type for OCI regions.
 type Region string
 
 const (
-	// OC1 REGIONS
+	instanceMetadataRegionInfoURLV2 = "http://169.254.169.254/opc/v2/instance/regionInfo"
 
-	// RegionIAD represents the region for US East (Ashburn).
-	RegionIAD Region = "us-ashburn-1"
-	// RegionPHX represents the region for US West (Phoenix).
-	RegionPHX Region = "us-phoenix-1"
-	// RegionUSSaltLake2 represents the region for US MidWest (Salt Lake).
-	RegionUSSaltLake2 Region = "us-saltlake-2"
-	// RegionUSSanJose1 represents the region for US West (San Jose).
-	RegionUSSanJose1 Region = "us-sanjose-1"
-	// RegionUSChicago1 represents the region for US Central (Chicago).
-	RegionUSChicago1 Region = "us-chicago-1"
-	// RegionCAMontreal1 represents the region for Canada Southeast (Montreal).
-	RegionCAMontreal1 Region = "ca-montreal-1"
-	// RegionCAToronto1 represents the region for Canada Southeast (Toronto).
-	RegionCAToronto1 Region = "ca-toronto-1"
-	// RegionLHR represents the region for UK South (London).
-	RegionLHR Region = "uk-london-1"
-	// RegionUKCardiff1 represents the region for the UK (Cardiff).
-	RegionUKCardiff1 Region = "uk-cardiff-1"
-	// RegionEUAmsterdam1 represents the region for Netherlands Northwest (Amsterdam).
-	RegionEUAmsterdam1 Region = "eu-amsterdam-1"
-	// RegionEUMadrid1 represents the region for Spain (Madrid).
-	RegionEUMadrid1 Region = "eu-madrid-1"
-	// RegionEUMilan1 represents the region for Italy (Milan).
-	RegionEUMilan1 Region = "eu-milan-1"
-	// RegionEUParis1 represents the region for France (Paris).
-	RegionEUParis1 Region = "eu-paris-1"
-	// RegionFRA represents the region for Germany Central (Frankfurt).
-	RegionFRA Region = "eu-frankfurt-1"
-	// RegionEUZurich1 represents the region for Switzerland North (Zurich).
-	RegionEUZurich1 Region = "eu-zurich-1"
-	// RegionAPTokyo1 represents the region for Japan East (Tokyo).
-	RegionAPTokyo1 Region = "ap-tokyo-1"
-	// RegionAPOsaka1 represents the region for Japan Central (Osaka).
-	RegionAPOsaka1 Region = "ap-osaka-1"
-	// RegionAPSeoul1 represents the region for South Korea Central (Seoul).
-	RegionAPSeoul1 Region = "ap-seoul-1"
-	// RegionAPChuncheon1 represents the region for South Korea North (Chuncheon).
-	RegionAPChuncheon1 Region = "ap-chuncheon-1"
-	// RegionAPMumbai1 represents the region for India West (Mumbai).
-	RegionAPMumbai1 Region = "ap-mumbai-1"
-	// RegionAPHyderabad1 represents the region for India South (Hyderabad).
-	RegionAPHyderabad1 Region = "ap-hyderabad-1"
-	// RegionAPSydney1 represents the region for Australia East (Sydney).
-	RegionAPSydney1 Region = "ap-sydney-1"
-	// RegionAPMelbourne1 represents the region for Australia Southeast (Melbourne).
-	RegionAPMelbourne1 Region = "ap-melbourne-1"
-	// RegionSABogota1 represents the region for Colombia
-	RegionSABogota1 Region = "sa-bogota-1"
-	// RegionSASaopaulo1 represents the region for Brazil East (Sao Paulo).
-	RegionSASaopaulo1 Region = "sa-saopaulo-1"
-	// RegionSASantiago1 represents the region for Chile (Santiago).
-	RegionSASantiago1 Region = "sa-santiago-1"
-	// RegionSAValparaiso1 represents the region for Chile (Valparaiso).
-	RegionSAValparaiso1 Region = "sa-valparaiso-1"
-	// RegionSAVinhedo1 represents the region for Brazil (Vinhedo).
-	RegionSAVinhedo1 Region = "sa-vinhedo-1"
-	// RegionMEJeddah1 represents the region for Saudi Arabia West (Jeddah).
-	RegionMEJeddah1 Region = "me-jeddah-1"
-	// RegionMEDubai1 represents the region for Saudi Arabia East (Dubai).
-	RegionMEDubai1 Region = "me-dubai-1"
-	// RegionMERiyadh1 represents the region for Riyadh
-	RegionMERiyadh1 Region = "me-riyadh-1"
-	// RegionMXQueretaro1 represents the region for Mexico (Queretaro).
-	RegionMXQueretaro1 Region = "mx-queretaro-1"
-	// RegionMXMonterrey1 represents the region for Mexico (Monterrey).
-	RegionMXMonterrey1 Region = "mx-monterrey-1"
-	// RegionILJerusalem1 represents the region for Israel (Jerusalem).
-	RegionILJerusalem1 Region = "il-jerusalem-1"
-	// RegionAFJohannesburg represents the region for Johannesburg
-	RegionAFJohannesburg Region = "af-johannesburg-1"
-	// RegionAPSingapore represents the region for singapore
-	RegionAPSingapore Region = "ap-singapore-1"
-	// RegionAPSingapore2 represents the second region for singapore
-	RegionAPSingapore2 Region = "ap-singapore-2"
-	// RegionEUMarseille represents the region for Marseille
-	RegionEUMarseille Region = "eu-marseille-1"
-	// RegionEUStockholm represents the region for Stockholm
-	RegionEUStockholm Region = "eu-stockholm-1"
-	// RegionMEAbudhabi represents the region for Abudhabi
-	RegionMEAbudhabi Region = "me-abudhabi-1"
+	// Region Metadata Configuration File
+	regionMetadataCfgDirName  = ".oci"
+	regionMetadataCfgFileName = "regions-config.json"
 
-	// OC2 REGIONS
+	// Region Metadata Environment Variable
+	regionMetadataEnvVarName = "OCI_REGION_METADATA"
 
-	// RegionUSLangley1 represents the region for Langley.
-	RegionUSLangley1 Region = "us-langley-1"
-	// RegionUSLuke1 represents the region for Luke.
-	RegionUSLuke1 Region = "us-luke-1"
+	// Default Realm Environment Variable: not used by NoSQL SDK
+	// defaultRealmEnvVarName = "OCI_DEFAULT_REALM"
 
-	// OC3 REGIONS
-
-	// RegionUSGovAshburn1 represents the government region for Ashburn.
-	RegionUSGovAshburn1 Region = "us-gov-ashburn-1"
-	// RegionUSGovChicago1 represents the government region for Chicago.
-	RegionUSGovChicago1 Region = "us-gov-chicago-1"
-	// RegionUSGovPhoenix1 represents the government region for Phoenix.
-	RegionUSGovPhoenix1 Region = "us-gov-phoenix-1"
-
-	// OC4 REGIONS
-
-	// RegionUKGovLondon1 represents the government region for London.
-	RegionUKGovLondon1 Region = "uk-gov-london-1"
-	// RegionUKGovCardiff1 represents the government region for Cardiff.
-	RegionUKGovCardiff1 Region = "uk-gov-cardiff-1"
-
-	// OC5 REGIONS
-
-	// RegionUSTacoma1 represents the Tacoma US region
-	RegionUSTacoma1 Region = "us-tacoma-1"
-
-	// OC8 REGIONS
-
-	// RegionAPChiyoda1 represents the region for Japan East (Chiyoda).
-	RegionAPChiyoda1 Region = "ap-chiyoda-1"
-	// RegionAPIbaraki1 represents the region for Japan East (Ibaraki).
-	RegionAPIbaraki1 Region = "ap-ibaraki-1"
-
-	// OC9 REGIONS
-
-	// RegionMEDCCMuscat represents the dedicated region for muscat
-	RegionMEDCCMuscat Region = "me-dcc-muscat-1"
-
-	// OC10 REGIONS
-
-	// RegionAPDCCCanberra represents the dedicated region for canberra
-	RegionAPDCCCanberra Region = "ap-dcc-canberra-1"
-
-	// OC14 REGIONS
-
-	// RegionEUDCCDublin1 represents the dedicated region for Dublin1
-	RegionEUDCCDublin1 Region = "eu-dcc-dublin-1"
-	// RegionEUDCCDublin2 represents the dedicated region for Dublin2
-	RegionEUDCCDublin2 Region = "eu-dcc-dublin-2"
-	// RegionEUDCCMilan1 represents the dedicated region for Milan1
-	RegionEUDCCMilan1 Region = "eu-dcc-milan-1"
-	// RegionEUDCCMilan2 represents the dedicated region for Milan2
-	RegionEUDCCMilan2 Region = "eu-dcc-milan-2"
-	// RegionEUDCCRating1 represents the dedicated region for Rating1
-	RegionEUDCCRating1 Region = "eu-dcc-rating-1"
-	// RegionEUDCCRating2 represents the dedicated region for Rating2
-	RegionEUDCCRating2 Region = "eu-dcc-rating-2"
-
-	// OC15 REGIONS
-
-	// RegionAPDCCGazipur1 represents the region for Bangladesh
-	RegionAPDCCGazipur1 Region = "ap-dcc-gazipur-1"
-
-	// OC16 REGIONS
-
-	// RegionUSWestJordan1 represents the region for west jordan (Utah)
-	RegionUSWestJordan1 Region = "us-westjordan-1"
-
-	// OC17 REGIONS
-
-	// RegionUSDCCPhoenix1 represents dedicated region 1 for Phoenix
-	RegionDCCPhoenix1 Region = "us-dcc-phoenix-1"
-	// RegionUSDCCPhoenix2 represents dedicated region 2 for Phoenix
-	RegionDCCPhoenix2 Region = "us-dcc-phoenix-2"
-	// RegionUSDCCPhoenix4 represents dedicated region 4 for Phoenix
-	RegionDCCPhoenix4 Region = "us-dcc-phoenix-4"
-
-	// OC19 REGIONS
-
-	// RegionEUFrankfurt2 represents the region for Frankfurt 2
-	RegionEUFrankfurt2 Region = "eu-frankfurt-2"
-	// RegionEUMadrid2 represents the region for Madrid 2
-	RegionEUMadrid2 Region = "eu-madrid-2"
-
-	// OC20 REGIONS
-
-	// RegionEUJovanovac1 represents the region for Jovanovac 1 (Serbia)
-	RegionEUJovanovac1 Region = "eu-jovanovac-1"
-
-	// OC21 REGIONS
-
-	// RegionMEDCCDoha1 represents the region for Qatar
-	RegionMEDCCDoha1 Region = "me-dcc-doha-1"
-
-	// OC22 REGIONS
-
-	// RegionEUJovanovac1 represents the dedicated region for Rome
-	RegionEUDCCRome1 Region = "eu-dcc-rome-1"
-
-	// OC23 REGIONS
-
-	// RegionUSSomerset1 represents the US somerset region
-	RegionUSSomerset1 Region = "us-somerset-1"
-	// RegionUSThames1 represents the US thames region
-	RegionUSThames1 Region = "us-thames-1"
-
-	// OC24 REGIONS
-
-	// RegionEUDCCZurich1 represents the dedicated region for Zurich
-	RegionEUDCCZurich1 Region = "eu-dcc-zurich-1"
-
-	// OC25 REGIONS
-
-	// RegionAPDCCTokyo1 represents the dedicated region for Tokyo
-	RegionAPDCCTokyo1 Region = "ap-dcc-tokyo-1"
-	// RegionAPDCCOsaka1 represents the dedicated region for Osaka
-	RegionAPDCCOsaka1 Region = "ap-dcc-osaka-1"
-
-	// OC26 REGIONS
-
-	// RegionMEAbudhabi3 represents the dedicated region for Abudabhi
-	RegionMEAbudhabi3 Region = "me-abudhabi-3"
-
-	// OC27 REGIONS
-
-	// RegionUSDCCSWJordan1 represents the dedicated region for SWJordan1
-	RegionUSDCCSWJordan1 Region = "us-dcc-swjordan-1"
-
-	// OC28 REGIONS
-
-	// RegionUSDCCSWJordan1 represents the dedicated region for SWJordan2
-	RegionUSDCCSWJordan2 Region = "us-dcc-swjordan-2"
-
-	// OC29 REGIONS
-
-	// RegionMEAbudhabi2 represents the region for abudhabi 2
-	RegionMEAbudhabi2 Region = "me-abudhabi-2"
-	// RegionMEAbudhabi4 represents the region for abudhabi 4
-	RegionMEAbudhabi4 Region = "me-abudhabi-4"
-
-	// OC31 REGIONS
-
-	// RegionAPHobsonville1 represents the dedicated region for Hobsonville
-	RegionAPHobsonville1 Region = "ap-hobsonville-1"
+	// Region Metadata
+	regionIdentifierPropertyName     = "regionIdentifier"     // e.g. "ap-sydney-1"
+	realmKeyPropertyName             = "realmKey"             // e.g. "oc1"
+	realmDomainComponentPropertyName = "realmDomainComponent" // e.g. "oraclecloud.com"
+	regionKeyPropertyName            = "regionKey"            // e.g. "SYD"
 )
 
-var realm = map[string]string{
-	"oc1":  "oraclecloud.com",
-	"oc2":  "oraclegovcloud.com",
-	"oc3":  "oraclegovcloud.com",
-	"oc4":  "oraclegovcloud.uk",
-	"oc5":  "oraclecloud5.com",
-	"oc8":  "oraclecloud8.com",
-	"oc9":  "oraclecloud9.com",
-	"oc10": "oraclecloud10.com",
-	"oc14": "oraclecloud14.com",
-	"oc15": "oraclecloud15.com",
-	"oc16": "oraclecloud16.com",
-	"oc17": "oraclecloud17.com",
-	"oc19": "oraclecloud.eu",
-	"oc20": "oraclecloud20.com",
-	"oc21": "oraclecloud21.com",
-	"oc22": "psn-pco.it",
-	"oc23": "oraclecloud23.com",
-	"oc24": "oraclecloud24.com",
-	"oc25": "nricloud.jp",
-	"oc26": "oraclecloud26.com",
-	"oc27": "oraclecloud27.com",
-	"oc28": "oraclecloud28.com",
-	"oc29": "oraclecloud29.com",
-	"oc31": "sovereigncloud.nz",
-}
+// External region metadata info flags, used to control adding these metadata region info only once.
+var readCfgFile, readEnvVar, visitIMDS bool = true, true, false
 
-var regionRealm = map[Region]string{
-	RegionPHX:            "oc1",
-	RegionIAD:            "oc1",
-	RegionFRA:            "oc1",
-	RegionLHR:            "oc1",
-	RegionUSSaltLake2:    "oc1",
-	RegionUSSanJose1:     "oc1",
-	RegionUSChicago1:     "oc1",
-	RegionUKCardiff1:     "oc1",
-	RegionCAToronto1:     "oc1",
-	RegionCAMontreal1:    "oc1",
-	RegionAPTokyo1:       "oc1",
-	RegionAPOsaka1:       "oc1",
-	RegionAPSeoul1:       "oc1",
-	RegionAPChuncheon1:   "oc1",
-	RegionAPSydney1:      "oc1",
-	RegionAPMumbai1:      "oc1",
-	RegionAPHyderabad1:   "oc1",
-	RegionAPMelbourne1:   "oc1",
-	RegionMEJeddah1:      "oc1",
-	RegionMEDubai1:       "oc1",
-	RegionMERiyadh1:      "oc1",
-	RegionMXQueretaro1:   "oc1",
-	RegionMXMonterrey1:   "oc1",
-	RegionILJerusalem1:   "oc1",
-	RegionEUZurich1:      "oc1",
-	RegionEUAmsterdam1:   "oc1",
-	RegionEUMadrid1:      "oc1",
-	RegionEUMilan1:       "oc1",
-	RegionEUParis1:       "oc1",
-	RegionSABogota1:      "oc1",
-	RegionSASaopaulo1:    "oc1",
-	RegionSASantiago1:    "oc1",
-	RegionSAVinhedo1:     "oc1",
-	RegionSAValparaiso1:  "oc1",
-	RegionAFJohannesburg: "oc1",
-	RegionAPSingapore:    "oc1",
-	RegionAPSingapore2:   "oc1",
-	RegionEUMarseille:    "oc1",
-	RegionMEAbudhabi:     "oc1",
-	RegionEUStockholm:    "oc1",
-
-	RegionUSLangley1: "oc2",
-	RegionUSLuke1:    "oc2",
-
-	RegionUSGovAshburn1: "oc3",
-	RegionUSGovChicago1: "oc3",
-	RegionUSGovPhoenix1: "oc3",
-
-	RegionUKGovLondon1:  "oc4",
-	RegionUKGovCardiff1: "oc4",
-
-	RegionUSTacoma1: "oc5",
-
-	RegionAPChiyoda1: "oc8",
-	RegionAPIbaraki1: "oc8",
-
-	RegionMEDCCMuscat: "oc9",
-
-	RegionAPDCCCanberra: "oc10",
-
-	RegionEUDCCDublin1: "oc14",
-	RegionEUDCCDublin2: "oc14",
-	RegionEUDCCMilan1:  "oc14",
-	RegionEUDCCMilan2:  "oc14",
-	RegionEUDCCRating1: "oc14",
-	RegionEUDCCRating2: "oc14",
-
-    RegionAPDCCGazipur1: "oc15",
-
-	RegionUSWestJordan1: "oc16",
-
-	RegionDCCPhoenix1: "oc17",
-	RegionDCCPhoenix2: "oc17",
-	RegionDCCPhoenix4: "oc17",
-
-	RegionEUFrankfurt2: "oc19",
-	RegionEUMadrid2:    "oc19",
-
-	RegionEUJovanovac1: "oc20",
-
-	RegionMEDCCDoha1: "oc21",
-
-	RegionEUDCCRome1: "oc22",
-
-	RegionUSSomerset1: "oc23",
-	RegionUSThames1:   "oc23",
-
-	RegionEUDCCZurich1: "oc24",
-
-	RegionAPDCCTokyo1: "oc25",
-	RegionAPDCCOsaka1: "oc25",
-
-	RegionMEAbudhabi3: "oc26",
-
-	RegionUSDCCSWJordan1: "oc27",
-
-	RegionUSDCCSWJordan2: "oc28",
-
-	RegionMEAbudhabi2: "oc29",
-	RegionMEAbudhabi4: "oc29",
-
-	RegionAPHobsonville1: "oc31",
-}
-
-var shortNameRegion = map[string]Region{
-	"phx": RegionPHX,
-	"iad": RegionIAD,
-	"aga": RegionUSSaltLake2,
-	"sjc": RegionUSSanJose1,
-	"ord": RegionUSChicago1,
-	"fra": RegionFRA,
-	"lhr": RegionLHR,
-	"cwl": RegionUKCardiff1,
-	"ams": RegionEUAmsterdam1,
-	"mad": RegionEUMadrid1,
-	"lin": RegionEUMilan1,
-	"cdg": RegionEUParis1,
-	"zrh": RegionEUZurich1,
-	"mel": RegionAPMelbourne1,
-	"bom": RegionAPMumbai1,
-	"hyd": RegionAPHyderabad1,
-	"bog": RegionSABogota1,
-	"gru": RegionSASaopaulo1,
-	"scl": RegionSASantiago1,
-	"vap": RegionSAValparaiso1,
-	"vcp": RegionSAVinhedo1,
-	"icn": RegionAPSeoul1,
-	"yny": RegionAPChuncheon1,
-	"nja": RegionAPChiyoda1,
-	// Note: ukb is actually Kobe, but OCI uses it for Ibaraki
-	"ukb": RegionAPIbaraki1,
-	"ibr": RegionAPIbaraki1,
-	"nrt": RegionAPTokyo1,
-	"kix": RegionAPOsaka1,
-	"yul": RegionCAMontreal1,
-	"yyz": RegionCAToronto1,
-	"jed": RegionMEJeddah1,
-	"dxb": RegionMEDubai1,
-	"ruh": RegionMERiyadh1,
-	"qro": RegionMXQueretaro1,
-	"mty": RegionMXMonterrey1,
-	"mtz": RegionILJerusalem1,
-	"syd": RegionAPSydney1,
-	"jnb": RegionAFJohannesburg,
-	"sin": RegionAPSingapore,
-	"xsp": RegionAPSingapore2,
-	"mrs": RegionEUMarseille,
-	"auh": RegionMEAbudhabi,
-	"arn": RegionEUStockholm,
-	"ltn": RegionUKGovLondon1,
-	"brs": RegionUKGovCardiff1,
-	"lfi": RegionUSLangley1,
-	"luf": RegionUSLuke1,
-	"tiw": RegionUSTacoma1,
-	"ric": RegionUSGovAshburn1,
-	"pia": RegionUSGovChicago1,
-	"tus": RegionUSGovPhoenix1,
-	"mct": RegionMEDCCMuscat,
-	"wga": RegionAPDCCCanberra,
-	"ork": RegionEUDCCDublin1,
-	"snn": RegionEUDCCDublin2,
-	"bgy": RegionEUDCCMilan1,
-	"mxp": RegionEUDCCMilan2,
-	"dus": RegionEUDCCRating1,
-	"dtm": RegionEUDCCRating2,
-	"dac": RegionAPDCCGazipur1,
-	"sgu": RegionUSWestJordan1,
-	"ifp": RegionDCCPhoenix1,
-	"gcn": RegionDCCPhoenix2,
-	"yum": RegionDCCPhoenix4,
-	"str": RegionEUFrankfurt2,
-	"vll": RegionEUMadrid2,
-	"doh": RegionMEDCCDoha1,
-	"beg": RegionEUJovanovac1,
-	"nap": RegionEUDCCRome1,
-	"ebb": RegionUSSomerset1,
-	"ebl": RegionUSThames1,
-	"avz": RegionEUDCCZurich1,
-	"tyo": RegionAPDCCTokyo1,
-	"uky": RegionAPDCCOsaka1,
-	"ahu": RegionMEAbudhabi3,
-	"ozz": RegionUSDCCSWJordan1,
-	"drs": RegionUSDCCSWJordan2,
-    "rkt": RegionMEAbudhabi2,
-    "shj": RegionMEAbudhabi4,
-	"izq": RegionAPHobsonville1,
-}
-
-func (region Region) secondLevelDomain() string {
+// realmDomain returns the realm domain for the region.
+// ex: region "us-ashburn-1" returns "oraclecloud.com"
+func (region Region) realmDomain() string {
 	if realmID, ok := regionRealm[region]; ok {
-		if secondLevelDomain, ok := realm[realmID]; ok {
-			return secondLevelDomain
+		if realmDomain, ok := realm[realmID]; ok {
+			return realmDomain
 		}
 	}
+
+	// Note: the OCI SDKs check for OCI_DEFAULT_REALM envorinment setting here.
+	// The NoSQL SDK does not use this, as the Region should already have
+	// a valid domain (or else the StringToRegion method would fail).
 
 	// Cannot find realm for region, return an empty string.
 	return ""
@@ -478,19 +66,19 @@ func (region Region) secondLevelDomain() string {
 // Endpoint returns the NoSQL service endpoint for the region.
 // An error is returned if region is invalid.
 func (region Region) Endpoint() (string, error) {
-	domain := region.secondLevelDomain()
+	domain := region.realmDomain()
 	if len(domain) == 0 {
 		return "", fmt.Errorf("region named %s is not recognized", string(region))
 	}
 
-	// Endpoint format: nosql.{regionID}.oci.{secondLevelDomain}
+	// Endpoint format: nosql.{regionID}.oci.{realmDomain}
 	return fmt.Sprintf("nosql.%s.oci.%s", string(region), domain), nil
 }
 
 // EndpointForService returns an endpoint for a service.
 // An error is returned if region is invalid.
 func (region Region) EndpointForService(service string) (string, error) {
-	domain := region.secondLevelDomain()
+	domain := region.realmDomain()
 	if len(domain) == 0 {
 		return "", fmt.Errorf("region named %s is not recognized", string(region))
 	}
@@ -517,5 +105,241 @@ func StringToRegion(regionKeyOrID string) (r Region, err error) {
 		return
 	}
 
+	//fmt.Printf("region named: %s, is not recognized from hard-coded region list, will check Region metadata info\n", regionStr)
+	r, err = checkAndAddRegionMetadata(regionStr)
+	if err == nil {
+		return
+	}
+
 	return "", fmt.Errorf("region named %s is not recognized", regionKeyOrID)
+}
+
+// The following code is taken from the OCI Go SDK, with minor modifications.
+
+// check region info from original map
+func checkAndAddRegionMetadata(region string) (Region, error) {
+	switch {
+	case setRegionMetadataFromCfgFile(&region):
+	case setRegionMetadataFromEnvVar(&region):
+	case setRegionFromInstanceMetadataService(&region):
+	default:
+		return "", fmt.Errorf("failed to get region metadata information")
+		//return Region(region)
+	}
+	return Region(region), nil
+}
+
+// EnableInstanceMetadataServiceLookup provides the interface to lookup IMDS region info
+func EnableInstanceMetadataServiceLookup() {
+	//fmt.Println("Set visitIMDS 'true' to enable IMDS Lookup.")
+	visitIMDS = true
+}
+
+// setRegionMetadataFromEnvVar checks if region metadata env variable is provided, once it's there, parse and added it
+// to region map, and it can make sure the env var can only be visited once.
+// Once successfully find the expected region(region name or short code), return true, region name will be stored in
+// the input pointer.
+func setRegionMetadataFromEnvVar(region *string) bool {
+	if !readEnvVar {
+		//fmt.Println("metadata region env variable had already been checked, no need to check again.")
+		return false //no need to check it again.
+	}
+	// Mark readEnvVar Flag as false since it has already been visited.
+	readEnvVar = false
+	// check from env variable
+	if jsonStr, existed := os.LookupEnv(regionMetadataEnvVarName); existed {
+		//fmt.Println("Raw content of region metadata env var:", jsonStr)
+		var regionSchema map[string]string
+		if err := json.Unmarshal([]byte(jsonStr), &regionSchema); err != nil {
+			//fmt.Println("Can't unmarshal env var, the error info is", err)
+			return false
+		}
+		// check if the specified region is in the env var.
+		if checkSchemaItems(regionSchema) {
+			// set mapping table
+			addRegionSchema(regionSchema)
+			if regionSchema[regionKeyPropertyName] == *region ||
+				regionSchema[regionIdentifierPropertyName] == *region {
+				*region = regionSchema[regionIdentifierPropertyName]
+				return true
+			}
+		}
+		return false
+	}
+	//fmt.Println("The Region Metadata Schema wasn't set in env variable - OCI_REGION_METADATA.")
+	return false
+}
+
+// setRegionMetadataFromCfgFile checks if region metadata config file is provided, once it's there, parse and add all
+// the valid regions to region map, the configuration file can only be visited once.
+// Once successfully find the expected region(region name or short code), return true, region name will be stored in
+// the input pointer.
+func setRegionMetadataFromCfgFile(region *string) bool {
+	if !readCfgFile {
+		//fmt.Println("metadata region config file had already been checked, no need to check again.")
+		return false //no need to check it again.
+	}
+	// Mark readCfgFile Flag as false since it has already been visited.
+	readCfgFile = false
+	homeFolder := getHomeFolder()
+	configFile := filepath.Join(homeFolder, regionMetadataCfgDirName, regionMetadataCfgFileName)
+	if jsonArr, ok := readAndParseConfigFile(&configFile); ok {
+		added := false
+		for _, jsonItem := range jsonArr {
+			if checkSchemaItems(jsonItem) {
+				addRegionSchema(jsonItem)
+				if jsonItem[regionKeyPropertyName] == *region ||
+					jsonItem[regionIdentifierPropertyName] == *region {
+					*region = jsonItem[regionIdentifierPropertyName]
+					added = true
+				}
+			}
+		}
+		return added
+	}
+	return false
+}
+
+func readAndParseConfigFile(configFileName *string) (fileContent []map[string]string, ok bool) {
+	if content, err := ioutil.ReadFile(*configFileName); err == nil {
+		//fmt.Println("Raw content of region metadata config file content:", string(content[:]))
+		if err := json.Unmarshal(content, &fileContent); err != nil {
+			//fmt.Println("Can't unmarshal config file, the error info is", err)
+			return
+		}
+		ok = true
+		return
+	}
+	//fmt.Println("No Region Metadata Config File provided.")
+	return
+}
+
+// check map regionRealm's region name, if it's already there, no need to add it.
+func addRegionSchema(regionSchema map[string]string) {
+	r := Region(strings.ToLower(regionSchema[regionIdentifierPropertyName]))
+	if _, ok := regionRealm[r]; !ok {
+		// set mapping table
+		shortNameRegion[regionSchema[regionKeyPropertyName]] = r
+		realm[regionSchema[realmKeyPropertyName]] = regionSchema[realmDomainComponentPropertyName]
+		regionRealm[r] = regionSchema[realmKeyPropertyName]
+		return
+	}
+	//fmt.Println("Region {} has already been added, no need to add again.", regionSchema[regionIdentifierPropertyName])
+}
+
+// check region schema content if all the required contents are provided
+func checkSchemaItems(regionSchema map[string]string) bool {
+	if checkSchemaItem(regionSchema, regionIdentifierPropertyName) &&
+		checkSchemaItem(regionSchema, realmKeyPropertyName) &&
+		checkSchemaItem(regionSchema, realmDomainComponentPropertyName) &&
+		checkSchemaItem(regionSchema, regionKeyPropertyName) {
+		return true
+	}
+	return false
+}
+
+// check region schema item is valid, if so, convert it to lower case.
+func checkSchemaItem(regionSchema map[string]string, key string) bool {
+	if val, ok := regionSchema[key]; ok {
+		if val != "" {
+			regionSchema[key] = strings.ToLower(val)
+			return true
+		}
+		//fmt.Println("Region metadata schema {} is provided,but content is empty.", key)
+		return false
+	}
+	//fmt.Println("Region metadata schema {} is not provided, please update the content", key)
+	return false
+}
+
+// setRegionFromInstanceMetadataService checks if region metadata can be provided from InstanceMetadataService.
+// Once successfully find the expected region(region name or short code), return true, region name will be stored in
+// the input pointer.
+// setRegionFromInstanceMetadataService will only be checked on the instance, by default it will not be enabled unless
+// user explicitly enable it.
+func setRegionFromInstanceMetadataService(region *string) bool {
+	// example of content:
+	// {
+	// 	"realmKey" : "oc1",
+	// 	"realmDomainComponent" : "oraclecloud.com",
+	// 	"regionKey" : "YUL",
+	// 	"regionIdentifier" : "ca-montreal-1"
+	// }
+	// Mark visitIMDS Flag as false since it has already been visited.
+	if !visitIMDS {
+		//fmt.Println("check from IMDS is disabled or IMDS had already been successfully visited, no need to check again.")
+		return false
+	}
+	content, err := getRegionInfoFromInstanceMetadataService()
+	if err != nil {
+		//fmt.Printf("Failed to get instance metadata. Error: %v\n", err)
+		return false
+	}
+
+	// Mark visitIMDS Flag as false since we have already successfully get the region info from IMDS.
+	visitIMDS = false
+
+	var regionInfo map[string]string
+	err = json.Unmarshal(content, &regionInfo)
+	if err != nil {
+		//fmt.Printf("Failed to unmarshal the response content: %v \nError: %v\n", string(content), err)
+		return false
+	}
+
+	if checkSchemaItems(regionInfo) {
+		addRegionSchema(regionInfo)
+		if regionInfo[regionKeyPropertyName] == *region ||
+			regionInfo[regionIdentifierPropertyName] == *region {
+			*region = regionInfo[regionIdentifierPropertyName]
+		}
+	} else {
+		//fmt.Println("Region information is not valid.")
+		return false
+	}
+
+	return true
+}
+
+// getRegionInfoFromInstanceMetadataService calls instance metadata service and get the region information
+func getRegionInfoFromInstanceMetadataService() ([]byte, error) {
+	request, _ := http.NewRequest(http.MethodGet, instanceMetadataRegionInfoURLV2, nil)
+	request.Header.Add("Authorization", "Bearer Oracle")
+
+	client := &http.Client{
+		Timeout: time.Second * 10,
+	}
+	resp, err := client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call instance metadata service. Error: %v", err)
+	}
+
+	statusCode := resp.StatusCode
+
+	defer resp.Body.Close()
+
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get region information from response body. Error: %v", err)
+	}
+
+	if statusCode != http.StatusOK {
+		err = fmt.Errorf("HTTP Get failed: URL: %s, Status: %s, Message: %s",
+			instanceMetadataRegionInfoURLV2, resp.Status, string(content))
+		return nil, err
+	}
+
+	return content, nil
+}
+
+func getHomeFolder() string {
+	current, e := user.Current()
+	if e != nil {
+		//Give up and try to return something sensible
+		home := os.Getenv("HOME")
+		if home == "" {
+			home = os.Getenv("USERPROFILE")
+		}
+		return home
+	}
+	return current.HomeDir
 }

--- a/nosqldb/common/region.go
+++ b/nosqldb/common/region.go
@@ -158,7 +158,8 @@ func setRegionMetadataFromEnvVar(region *string) bool {
 		if checkSchemaItems(regionSchema) {
 			// set mapping table
 			addRegionSchema(regionSchema)
-			if regionSchema[regionKeyPropertyName] == *region ||
+			if *region == "" ||
+				regionSchema[regionKeyPropertyName] == *region ||
 				regionSchema[regionIdentifierPropertyName] == *region {
 				*region = regionSchema[regionIdentifierPropertyName]
 				return true
@@ -288,7 +289,8 @@ func setRegionFromInstanceMetadataService(region *string) bool {
 
 	if checkSchemaItems(regionInfo) {
 		addRegionSchema(regionInfo)
-		if regionInfo[regionKeyPropertyName] == *region ||
+		if *region == "" ||
+			regionInfo[regionKeyPropertyName] == *region ||
 			regionInfo[regionIdentifierPropertyName] == *region {
 			*region = regionInfo[regionIdentifierPropertyName]
 		}

--- a/nosqldb/common/region_codes.go
+++ b/nosqldb/common/region_codes.go
@@ -5,6 +5,8 @@
 //  https://oss.oracle.com/licenses/upl/
 //
 
+// NOTE: this file is auto-generated. Do not modify it manually.
+
 // Package common provides common utilities used for NoSQL client.
 package common
 

--- a/nosqldb/common/region_codes.go
+++ b/nosqldb/common/region_codes.go
@@ -1,0 +1,292 @@
+//
+// Copyright (c) 2019, 2024 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Universal Permissive License v 1.0 as shown at
+//  https://oss.oracle.com/licenses/upl/
+//
+
+// Package common provides common utilities used for NoSQL client.
+package common
+
+const (
+	RegionAfJohannesburg1 Region = "af-johannesburg-1"
+	RegionApChuncheon1 Region = "ap-chuncheon-1"
+	RegionApHyderabad1 Region = "ap-hyderabad-1"
+	RegionApMelbourne1 Region = "ap-melbourne-1"
+	RegionApMumbai1 Region = "ap-mumbai-1"
+	RegionApOsaka1 Region = "ap-osaka-1"
+	RegionApSeoul1 Region = "ap-seoul-1"
+	RegionApSingapore1 Region = "ap-singapore-1"
+	RegionApSingapore2 Region = "ap-singapore-2"
+	RegionApSydney1 Region = "ap-sydney-1"
+	RegionApTokyo1 Region = "ap-tokyo-1"
+	RegionCaMontreal1 Region = "ca-montreal-1"
+	RegionCaToronto1 Region = "ca-toronto-1"
+	RegionEuAmsterdam1 Region = "eu-amsterdam-1"
+	RegionEuFrankfurt1 Region = "eu-frankfurt-1"
+	RegionEuMadrid1 Region = "eu-madrid-1"
+	RegionEuMarseille1 Region = "eu-marseille-1"
+	RegionEuMilan1 Region = "eu-milan-1"
+	RegionEuParis1 Region = "eu-paris-1"
+	RegionEuStockholm1 Region = "eu-stockholm-1"
+	RegionEuZurich1 Region = "eu-zurich-1"
+	RegionIlJerusalem1 Region = "il-jerusalem-1"
+	RegionMeAbudhabi1 Region = "me-abudhabi-1"
+	RegionMeDubai1 Region = "me-dubai-1"
+	RegionMeJeddah1 Region = "me-jeddah-1"
+	RegionMeRiyadh1 Region = "me-riyadh-1"
+	RegionMxMonterrey1 Region = "mx-monterrey-1"
+	RegionMxQueretaro1 Region = "mx-queretaro-1"
+	RegionSaBogota1 Region = "sa-bogota-1"
+	RegionSaSantiago1 Region = "sa-santiago-1"
+	RegionSaSaopaulo1 Region = "sa-saopaulo-1"
+	RegionSaValparaiso1 Region = "sa-valparaiso-1"
+	RegionSaVinhedo1 Region = "sa-vinhedo-1"
+	RegionUkLondon1 Region = "uk-london-1"
+	RegionUkCardiff1 Region = "uk-cardiff-1"
+	RegionUsPhoenix1 Region = "us-phoenix-1"
+	RegionUsAshburn1 Region = "us-ashburn-1"
+	RegionUsSaltlake2 Region = "us-saltlake-2"
+	RegionUsSanjose1 Region = "us-sanjose-1"
+	RegionUsChicago1 Region = "us-chicago-1"
+	RegionUsLangley1 Region = "us-langley-1"
+	RegionUsLuke1 Region = "us-luke-1"
+	RegionUsTacoma1 Region = "us-tacoma-1"
+	RegionApChiyoda1 Region = "ap-chiyoda-1"
+	RegionApIbaraki1 Region = "ap-ibaraki-1"
+	RegionUsWestjordan1 Region = "us-westjordan-1"
+	RegionEuFrankfurt2 Region = "eu-frankfurt-2"
+	RegionEuMadrid2 Region = "eu-madrid-2"
+	RegionEuJovanovac1 Region = "eu-jovanovac-1"
+	RegionUsSomerset1 Region = "us-somerset-1"
+	RegionUsThames1 Region = "us-thames-1"
+	RegionEuCrissier1 Region = "eu-crissier-1"
+	RegionMeAbudhabi3 Region = "me-abudhabi-3"
+	RegionMeAlain1 Region = "me-alain-1"
+	RegionMeAbudhabi2 Region = "me-abudhabi-2"
+	RegionMeAbudhabi4 Region = "me-abudhabi-4"
+	RegionApHobsonville1 Region = "ap-hobsonville-1"
+	RegionApSuwon1 Region = "ap-suwon-1"
+	RegionUsGovAshburn1 Region = "us-gov-ashburn-1"
+	RegionUsGovChicago1 Region = "us-gov-chicago-1"
+	RegionUsGovPhoenix1 Region = "us-gov-phoenix-1"
+	RegionUkGovLondon1 Region = "uk-gov-london-1"
+	RegionUkGovCardiff1 Region = "uk-gov-cardiff-1"
+	RegionMeDccMuscat1 Region = "me-dcc-muscat-1"
+	RegionApDccCanberra1 Region = "ap-dcc-canberra-1"
+	RegionEuDccDublin1 Region = "eu-dcc-dublin-1"
+	RegionEuDccDublin2 Region = "eu-dcc-dublin-2"
+	RegionEuDccMilan1 Region = "eu-dcc-milan-1"
+	RegionEuDccMilan2 Region = "eu-dcc-milan-2"
+	RegionEuDccRating1 Region = "eu-dcc-rating-1"
+	RegionEuDccRating2 Region = "eu-dcc-rating-2"
+	RegionApDccGazipur1 Region = "ap-dcc-gazipur-1"
+	RegionUsDccPhoenix1 Region = "us-dcc-phoenix-1"
+	RegionUsDccPhoenix2 Region = "us-dcc-phoenix-2"
+	RegionUsDccPhoenix4 Region = "us-dcc-phoenix-4"
+	RegionMeDccDoha1 Region = "me-dcc-doha-1"
+	RegionEuDccRome1 Region = "eu-dcc-rome-1"
+	RegionEuDccZurich1 Region = "eu-dcc-zurich-1"
+	RegionApDccOsaka1 Region = "ap-dcc-osaka-1"
+	RegionApDccTokyo1 Region = "ap-dcc-tokyo-1"
+	RegionUsDccSwjordan1 Region = "us-dcc-swjordan-1"
+	RegionUsDccSwjordan2 Region = "us-dcc-swjordan-2"
+)
+
+var realm = map[string]string{
+	"oc1": "oraclecloud.com",
+	"oc10": "oraclecloud10.com",
+	"oc14": "oraclecloud14.com",
+	"oc15": "oraclecloud15.com",
+	"oc16": "oraclecloud16.com",
+	"oc17": "oraclecloud17.com",
+	"oc19": "oraclecloud.eu",
+	"oc2": "oraclegovcloud.com",
+	"oc20": "oraclecloud20.com",
+	"oc21": "oraclecloud21.com",
+	"oc22": "psn-pco.it",
+	"oc23": "oraclecloud23.com",
+	"oc24": "oraclecloud24.com",
+	"oc25": "nricloud.jp",
+	"oc26": "oraclecloud26.com",
+	"oc27": "oraclecloud27.com",
+	"oc28": "oraclecloud28.com",
+	"oc29": "oraclecloud29.com",
+	"oc3": "oraclegovcloud.com",
+	"oc31": "sovereigncloud.nz",
+	"oc35": "oraclecloud35.com",
+	"oc4": "oraclegovcloud.uk",
+	"oc5": "oraclecloud5.com",
+	"oc8": "oraclecloud8.com",
+	"oc9": "oraclecloud9.com",
+}
+
+var regionRealm = map[Region]string{
+	RegionAfJohannesburg1: "oc1",
+	RegionApChuncheon1: "oc1",
+	RegionApHyderabad1: "oc1",
+	RegionApMelbourne1: "oc1",
+	RegionApMumbai1: "oc1",
+	RegionApOsaka1: "oc1",
+	RegionApSeoul1: "oc1",
+	RegionApSingapore1: "oc1",
+	RegionApSingapore2: "oc1",
+	RegionApSydney1: "oc1",
+	RegionApTokyo1: "oc1",
+	RegionCaMontreal1: "oc1",
+	RegionCaToronto1: "oc1",
+	RegionEuAmsterdam1: "oc1",
+	RegionEuFrankfurt1: "oc1",
+	RegionEuMadrid1: "oc1",
+	RegionEuMarseille1: "oc1",
+	RegionEuMilan1: "oc1",
+	RegionEuParis1: "oc1",
+	RegionEuStockholm1: "oc1",
+	RegionEuZurich1: "oc1",
+	RegionIlJerusalem1: "oc1",
+	RegionMeAbudhabi1: "oc1",
+	RegionMeDubai1: "oc1",
+	RegionMeJeddah1: "oc1",
+	RegionMeRiyadh1: "oc1",
+	RegionMxMonterrey1: "oc1",
+	RegionMxQueretaro1: "oc1",
+	RegionSaBogota1: "oc1",
+	RegionSaSantiago1: "oc1",
+	RegionSaSaopaulo1: "oc1",
+	RegionSaValparaiso1: "oc1",
+	RegionSaVinhedo1: "oc1",
+	RegionUkLondon1: "oc1",
+	RegionUkCardiff1: "oc1",
+	RegionUsPhoenix1: "oc1",
+	RegionUsAshburn1: "oc1",
+	RegionUsSaltlake2: "oc1",
+	RegionUsSanjose1: "oc1",
+	RegionUsChicago1: "oc1",
+	RegionUsLangley1: "oc2",
+	RegionUsLuke1: "oc2",
+	RegionUsGovAshburn1: "oc3",
+	RegionUsGovChicago1: "oc3",
+	RegionUsGovPhoenix1: "oc3",
+	RegionUkGovLondon1: "oc4",
+	RegionUkGovCardiff1: "oc4",
+	RegionUsTacoma1: "oc5",
+	RegionApChiyoda1: "oc8",
+	RegionApIbaraki1: "oc8",
+	RegionMeDccMuscat1: "oc9",
+	RegionApDccCanberra1: "oc10",
+	RegionEuDccDublin1: "oc14",
+	RegionEuDccDublin2: "oc14",
+	RegionEuDccMilan1: "oc14",
+	RegionEuDccMilan2: "oc14",
+	RegionEuDccRating1: "oc14",
+	RegionEuDccRating2: "oc14",
+	RegionApDccGazipur1: "oc15",
+	RegionUsWestjordan1: "oc16",
+	RegionUsDccPhoenix1: "oc17",
+	RegionUsDccPhoenix2: "oc17",
+	RegionUsDccPhoenix4: "oc17",
+	RegionEuFrankfurt2: "oc19",
+	RegionEuMadrid2: "oc19",
+	RegionEuJovanovac1: "oc20",
+	RegionMeDccDoha1: "oc21",
+	RegionEuDccRome1: "oc22",
+	RegionUsSomerset1: "oc23",
+	RegionUsThames1: "oc23",
+	RegionEuDccZurich1: "oc24",
+	RegionEuCrissier1: "oc24",
+	RegionApDccOsaka1: "oc25",
+	RegionApDccTokyo1: "oc25",
+	RegionMeAbudhabi3: "oc26",
+	RegionMeAlain1: "oc26",
+	RegionUsDccSwjordan1: "oc27",
+	RegionUsDccSwjordan2: "oc28",
+	RegionMeAbudhabi2: "oc29",
+	RegionMeAbudhabi4: "oc29",
+	RegionApHobsonville1: "oc31",
+	RegionApSuwon1: "oc35",
+}
+
+var shortNameRegion = map[string]Region{
+	"jnb": RegionAfJohannesburg1,
+	"yny": RegionApChuncheon1,
+	"hyd": RegionApHyderabad1,
+	"mel": RegionApMelbourne1,
+	"bom": RegionApMumbai1,
+	"kix": RegionApOsaka1,
+	"icn": RegionApSeoul1,
+	"sin": RegionApSingapore1,
+	"xsp": RegionApSingapore2,
+	"syd": RegionApSydney1,
+	"nrt": RegionApTokyo1,
+	"yul": RegionCaMontreal1,
+	"yyz": RegionCaToronto1,
+	"ams": RegionEuAmsterdam1,
+	"fra": RegionEuFrankfurt1,
+	"mad": RegionEuMadrid1,
+	"mrs": RegionEuMarseille1,
+	"lin": RegionEuMilan1,
+	"cdg": RegionEuParis1,
+	"arn": RegionEuStockholm1,
+	"zrh": RegionEuZurich1,
+	"mtz": RegionIlJerusalem1,
+	"auh": RegionMeAbudhabi1,
+	"dxb": RegionMeDubai1,
+	"jed": RegionMeJeddah1,
+	"ruh": RegionMeRiyadh1,
+	"mty": RegionMxMonterrey1,
+	"qro": RegionMxQueretaro1,
+	"bog": RegionSaBogota1,
+	"scl": RegionSaSantiago1,
+	"gru": RegionSaSaopaulo1,
+	"vap": RegionSaValparaiso1,
+	"vcp": RegionSaVinhedo1,
+	"lhr": RegionUkLondon1,
+	"cwl": RegionUkCardiff1,
+	"phx": RegionUsPhoenix1,
+	"iad": RegionUsAshburn1,
+	"aga": RegionUsSaltlake2,
+	"sjc": RegionUsSanjose1,
+	"ord": RegionUsChicago1,
+	"lfi": RegionUsLangley1,
+	"luf": RegionUsLuke1,
+	"ric": RegionUsGovAshburn1,
+	"pia": RegionUsGovChicago1,
+	"tus": RegionUsGovPhoenix1,
+	"ltn": RegionUkGovLondon1,
+	"brs": RegionUkGovCardiff1,
+	"tiw": RegionUsTacoma1,
+	"nja": RegionApChiyoda1,
+	"ukb": RegionApIbaraki1,
+	"mct": RegionMeDccMuscat1,
+	"wga": RegionApDccCanberra1,
+	"ork": RegionEuDccDublin1,
+	"snn": RegionEuDccDublin2,
+	"bgy": RegionEuDccMilan1,
+	"mxp": RegionEuDccMilan2,
+	"dus": RegionEuDccRating1,
+	"dtm": RegionEuDccRating2,
+	"dac": RegionApDccGazipur1,
+	"sgu": RegionUsWestjordan1,
+	"ifp": RegionUsDccPhoenix1,
+	"gcn": RegionUsDccPhoenix2,
+	"yum": RegionUsDccPhoenix4,
+	"str": RegionEuFrankfurt2,
+	"vll": RegionEuMadrid2,
+	"beg": RegionEuJovanovac1,
+	"doh": RegionMeDccDoha1,
+	"nap": RegionEuDccRome1,
+	"ebb": RegionUsSomerset1,
+	"ebl": RegionUsThames1,
+	"avz": RegionEuDccZurich1,
+	"avf": RegionEuCrissier1,
+	"uky": RegionApDccOsaka1,
+	"tyo": RegionApDccTokyo1,
+	"ahu": RegionMeAbudhabi3,
+	"rba": RegionMeAlain1,
+	"ozz": RegionUsDccSwjordan1,
+	"drs": RegionUsDccSwjordan2,
+	"rkt": RegionMeAbudhabi2,
+	"shj": RegionMeAbudhabi4,
+	"izq": RegionApHobsonville1,
+	"dln": RegionApSuwon1,
+}

--- a/nosqldb/common/region_test.go
+++ b/nosqldb/common/region_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -30,33 +31,33 @@ var regionTests = []regionEP{
 	{Region(""), ""},
 	{Region("RegionNA"), ""},
 	// realm: oc1
-	{RegionCAToronto1, "nosql.ca-toronto-1.oci.oraclecloud.com"},
-	{RegionCAMontreal1, "nosql.ca-montreal-1.oci.oraclecloud.com"},
-	{RegionPHX, "nosql.us-phoenix-1.oci.oraclecloud.com"},
-	{RegionIAD, "nosql.us-ashburn-1.oci.oraclecloud.com"},
-	{RegionFRA, "nosql.eu-frankfurt-1.oci.oraclecloud.com"},
-	{RegionEUAmsterdam1, "nosql.eu-amsterdam-1.oci.oraclecloud.com"},
-	{RegionLHR, "nosql.uk-london-1.oci.oraclecloud.com"},
-	{RegionAPTokyo1, "nosql.ap-tokyo-1.oci.oraclecloud.com"},
-	{RegionAPOsaka1, "nosql.ap-osaka-1.oci.oraclecloud.com"},
-	{RegionAPSeoul1, "nosql.ap-seoul-1.oci.oraclecloud.com"},
-	{RegionAPChuncheon1, "nosql.ap-chuncheon-1.oci.oraclecloud.com"},
-	{RegionAPMumbai1, "nosql.ap-mumbai-1.oci.oraclecloud.com"},
-	{RegionAPHyderabad1, "nosql.ap-hyderabad-1.oci.oraclecloud.com"},
-	{RegionEUZurich1, "nosql.eu-zurich-1.oci.oraclecloud.com"},
-	{RegionSASaopaulo1, "nosql.sa-saopaulo-1.oci.oraclecloud.com"},
-	{RegionAPSydney1, "nosql.ap-sydney-1.oci.oraclecloud.com"},
-	{RegionAPMelbourne1, "nosql.ap-melbourne-1.oci.oraclecloud.com"},
-	{RegionMEJeddah1, "nosql.me-jeddah-1.oci.oraclecloud.com"},
+	{RegionCaToronto1, "nosql.ca-toronto-1.oci.oraclecloud.com"},
+	{RegionCaMontreal1, "nosql.ca-montreal-1.oci.oraclecloud.com"},
+	{RegionUsPhoenix1, "nosql.us-phoenix-1.oci.oraclecloud.com"},
+	{RegionUsAshburn1, "nosql.us-ashburn-1.oci.oraclecloud.com"},
+	{RegionEuFrankfurt1, "nosql.eu-frankfurt-1.oci.oraclecloud.com"},
+	{RegionEuAmsterdam1, "nosql.eu-amsterdam-1.oci.oraclecloud.com"},
+	{RegionUkLondon1, "nosql.uk-london-1.oci.oraclecloud.com"},
+	{RegionApTokyo1, "nosql.ap-tokyo-1.oci.oraclecloud.com"},
+	{RegionApOsaka1, "nosql.ap-osaka-1.oci.oraclecloud.com"},
+	{RegionApSeoul1, "nosql.ap-seoul-1.oci.oraclecloud.com"},
+	{RegionApChuncheon1, "nosql.ap-chuncheon-1.oci.oraclecloud.com"},
+	{RegionApMumbai1, "nosql.ap-mumbai-1.oci.oraclecloud.com"},
+	{RegionApHyderabad1, "nosql.ap-hyderabad-1.oci.oraclecloud.com"},
+	{RegionEuZurich1, "nosql.eu-zurich-1.oci.oraclecloud.com"},
+	{RegionSaSaopaulo1, "nosql.sa-saopaulo-1.oci.oraclecloud.com"},
+	{RegionApSydney1, "nosql.ap-sydney-1.oci.oraclecloud.com"},
+	{RegionApMelbourne1, "nosql.ap-melbourne-1.oci.oraclecloud.com"},
+	{RegionMeJeddah1, "nosql.me-jeddah-1.oci.oraclecloud.com"},
 	// realm: oc2
-	{RegionUSLangley1, "nosql.us-langley-1.oci.oraclegovcloud.com"},
-	{RegionUSLuke1, "nosql.us-luke-1.oci.oraclegovcloud.com"},
+	{RegionUsLangley1, "nosql.us-langley-1.oci.oraclegovcloud.com"},
+	{RegionUsLuke1, "nosql.us-luke-1.oci.oraclegovcloud.com"},
 	// realm: oc3
-	{RegionUSGovAshburn1, "nosql.us-gov-ashburn-1.oci.oraclegovcloud.com"},
-	{RegionUSGovChicago1, "nosql.us-gov-chicago-1.oci.oraclegovcloud.com"},
-	{RegionUSGovPhoenix1, "nosql.us-gov-phoenix-1.oci.oraclegovcloud.com"},
+	{RegionUsGovAshburn1, "nosql.us-gov-ashburn-1.oci.oraclegovcloud.com"},
+	{RegionUsGovChicago1, "nosql.us-gov-chicago-1.oci.oraclegovcloud.com"},
+	{RegionUsGovPhoenix1, "nosql.us-gov-phoenix-1.oci.oraclegovcloud.com"},
 	// realm: oc4
-	{RegionUKGovLondon1, "nosql.uk-gov-london-1.oci.oraclegovcloud.uk"},
+	{RegionUkGovLondon1, "nosql.uk-gov-london-1.oci.oraclegovcloud.uk"},
 }
 
 func TestEndpointForRegion(t *testing.T) {
@@ -77,8 +78,8 @@ func TestEndpointForService(t *testing.T) {
 		wantEndpoint string
 		wantErr      bool
 	}{
-		{RegionIAD, "auth", "auth.us-ashburn-1.oraclecloud.com", false},
-		{RegionPHX, "foo", "foo.us-phoenix-1.oraclecloud.com", false},
+		{RegionUsAshburn1, "auth", "auth.us-ashburn-1.oraclecloud.com", false},
+		{RegionUsPhoenix1, "foo", "foo.us-phoenix-1.oraclecloud.com", false},
 		{"RegionNA", "bar", "", true},
 	}
 
@@ -90,6 +91,28 @@ func TestEndpointForService(t *testing.T) {
 			assert.Equalf(t, r.wantEndpoint, ep, "EndpointForService() got unexpected service endpoint")
 		}
 	}
+}
+
+func setupOCIRegionsEnv() {
+	// OCI environment
+	os.Setenv("OCI_REGION_METADATA", `{"realmKey":"OC50","realmDomainComponent":"oraclecloud50.com","regionKey":"ENV","regionIdentifier":"us-fromenv-1"}`)
+}
+
+func setupOCIRegionsFile() {
+	// OCI config file... we may have to create a ~/.oci directory
+	configDir := filepath.Join(getHomeFolder(), ".oci")
+	os.Mkdir(configDir, 0777)
+	configFile := filepath.Join(getHomeFolder(), ".oci/regions-config.json")
+	os.WriteFile(configFile, []byte(`[{"realmKey":"OC55","realmDomainComponent":"oraclecloud55.com","regionKey":"FIL","regionIdentifier":"us-fromfil-1"},{"realmKey":"OC70","realmDomainComponent":"oraclecloud70.com","regionKey":"ZZZ","regionIdentifier":"us-fromzzz-1"}]`), 0777)
+}
+
+func unsetOCIRegionsEnv() {
+	os.Unsetenv("OCI_REGION_METADATA")
+}
+
+func unsetOCIRegionsFile() {
+	configFile := filepath.Join(getHomeFolder(), ".oci/regions-config.json")
+	os.Remove(configFile)
 }
 
 func TestStringToRegion(t *testing.T) {
@@ -129,6 +152,39 @@ func TestStringToRegion(t *testing.T) {
 		assert.NoErrorf(t, err, "StringToRegion(%q) got error %v", s, err)
 	}
 
+	// OCI environment
+	envRegionKeys := []string{
+		"env", "us-fromenv-1",
+	}
+	setupOCIRegionsEnv()
+	defer unsetOCIRegionsEnv()
+	for _, s := range envRegionKeys {
+		_, err = StringToRegion(s)
+		assert.NoErrorf(t, err, "StringToRegion(%q) got error %v", s, err)
+		s = strings.ToUpper(s)
+		_, err = StringToRegion(s)
+		assert.NoErrorf(t, err, "StringToRegion(%q) got error %v", s, err)
+		readCfgFile, readEnvVar, visitIMDS = true, true, false
+	}
+	unsetOCIRegionsEnv()
+
+	// OCI config file
+	fileRegionKeys := []string{
+		"fil", "us-fromfil-1",
+		"zzz", "us-fromzzz-1",
+	}
+	setupOCIRegionsFile()
+	defer unsetOCIRegionsFile()
+	for _, s := range fileRegionKeys {
+		_, err = StringToRegion(s)
+		assert.NoErrorf(t, err, "StringToRegion(%q) got error %v", s, err)
+		s = strings.ToUpper(s)
+		_, err = StringToRegion(s)
+		assert.NoErrorf(t, err, "StringToRegion(%q) got error %v", s, err)
+	}
+	unsetOCIRegionsFile()
+
+	// Invalid regions
 	badRegionKeyOrIDs := []string{
 		"", "oci",
 		"xyz", "ca-toronto-x",


### PR DESCRIPTION
## Added
- Cloud only: Added the capability to determine region metadata from OCI configuration.
  This enables using new regions that may not have been added to the SDK code yet, without
  having to specify a full NoSQL endpoint parameter.
  See [Adding Regions](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdk_adding_new_region_endpoints.htm) for more information.

## Changed
- Cloud only: Internal OCI `Region` definitions have been updated to be consistent. Some previous
  shorthand `Region`s have been removed, for example `RegionPHX` and `RegionIAD`. This should not affect any
  external usage, as the `Region` definitions are intended for internal logic only. Interaction
  with the NoSQL APIs should always use region identifier strings, such as `us-phoenix-1`, or
  full endpoint strings, such as `nosql.us-phoenix-1.oci.oraclecloud.com`.
