### PR TITLE
Added ReprepareQuery error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
   This enables using new regions that may not have been added to the SDK code yet, without
   having to specify a full NoSQL endpoint parameter.
   See [Adding Regions](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdk_adding_new_region_endpoints.htm) for more information.
+- ReprepareQuery error code: This error is returned if a prepared query is executed
+  after (a) the index used by the query has been dropped and then re-created with a
+  different schema, or (b) one or more of the referenced tables has been altered
+  (via the alter table statement).
 
 ## Changed
 - Cloud only: Internal OCI `Region` definitions have been updated to be consistent. Some previous

--- a/nosqldb/nosqlerr/errors.go
+++ b/nosqldb/nosqlerr/errors.go
@@ -280,6 +280,11 @@ const (
 	// UnsupportedQueryVersion error indicates the version of query used in the SDK is
 	// not supported by the server, and the SDK should downgrade its handling of query objects.
 	UnsupportedQueryVersion // 27
+
+	// ReprepareQuery error indicates the prepared query must be re-prepared. This is typically
+	// due to a prepared query being used after DDL changes to the tables and/or indexes accessed
+	// by the query. The application should re-prepare the query and submit the query request again.
+	ReprepareQuery // 28
 )
 
 const (

--- a/nosqldb/query_test.go
+++ b/nosqldb/query_test.go
@@ -297,9 +297,9 @@ func (suite *QueryTestSuite) TestEvolution() {
 	suite.ExecuteTableDDL(fmt.Sprintf("alter table %s (drop age)", tableName))
 
 	_, err = suite.ExecuteQueryRequest(req)
-	suite.Require().Truef(nosqlerr.IsIllegalArgument(err),
+	suite.Require().Truef(nosqlerr.Is(err, nosqlerr.IllegalArgument, nosqlerr.ReprepareQuery),
 		"Query(%s) should have failed with an "+
-			"IllegalArgument error, got error %v.", stmt, err)
+			"IllegalArgument or ReprepareQuery error, got error %v.", stmt, err)
 }
 
 func (suite *QueryTestSuite) TestPrepare() {


### PR DESCRIPTION
This error is returned if a prepared query is executed after (a) the index used by the query has been dropped and then re-created with a different schema, or (b) one or more of the referenced tables has been altered (via the alter table statement).