### PR TITLE
fix for security related issues

### DIFF
--- a/nosqldb/httputil/httputil.go
+++ b/nosqldb/httputil/httputil.go
@@ -140,8 +140,8 @@ DoRetry:
 		}
 
 		// Retry if status code >= 500.
-		logger.Fine("Remote server temporarily unavailable, status code: %d, response: %s",
-			resp.Code, string(resp.Body))
+		logger.Fine("Remote server temporarily unavailable, status code: %d, response body omitted, body length: %d bytes",
+			resp.Code, len(resp.Body))
 		delay = (1 << (numAttempts - 1)) * retryInterval
 		logger.Fine("DoRequest(): number of attempts: %d, will retry in %v.", numAttempts, delay)
 

--- a/nosqldb/internal/sdkutil/properties.go
+++ b/nosqldb/internal/sdkutil/properties.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -22,8 +23,7 @@ import (
 // Properties is used to read and write properties files.
 // The properties in the file must be written in the form:
 //
-//   name=value
-//
+//	name=value
 type Properties struct {
 	file  string
 	props map[string]string
@@ -117,12 +117,27 @@ func (p *Properties) Save() error {
 		buf.WriteString(fmt.Sprintf("%s=%s\n", k, v))
 	}
 
-	tmpFile := fmt.Sprintf("%s.tmp", p.file)
-	perm := os.FileMode(0644)
-	if err := os.WriteFile(tmpFile, buf.Bytes(), perm); err != nil {
+	// Properties files may contain credentials, so saved files should be owner-only.
+	perm := os.FileMode(0600)
+	tmpFile, err := os.CreateTemp(filepath.Dir(p.file), filepath.Base(p.file)+".tmp.")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmpFile, p.file)
+	tmpName := tmpFile.Name()
+	defer os.Remove(tmpName)
+
+	if err := tmpFile.Chmod(perm); err != nil {
+		tmpFile.Close()
+		return err
+	}
+	if _, err := tmpFile.Write(buf.Bytes()); err != nil {
+		tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, p.file)
 }
 
 // Get reads the property associated with key.

--- a/nosqldb/internal/sdkutil/properties_test.go
+++ b/nosqldb/internal/sdkutil/properties_test.go
@@ -13,6 +13,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"runtime"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -158,6 +159,85 @@ func (suite *PropTestSuite) TestPut() {
 		suite.Greaterf(fileInfo.Size(), int64(0), "got unexpected file size for %s", name)
 	}
 
+}
+
+func (suite *PropTestSuite) TestSaveUsesPrivatePermissions() {
+	if runtime.GOOS == "windows" {
+		suite.T().Skip("Unix file permission bits are not enforced on Windows")
+	}
+
+	f, err := os.CreateTemp("", "go-driver-test-*.properties")
+	if !suite.NoErrorf(err, "failed to create a temporary file for testing") {
+		return
+	}
+	name := f.Name()
+	f.Close()
+	defer os.Remove(name)
+
+	p, err := NewProperties(name)
+	if !suite.NoErrorf(err, "NewProperties(%s) got error %v", name, err) {
+		return
+	}
+
+	p.Put("username", "user1")
+	p.Put("password", "secret")
+	if !suite.NoErrorf(p.Save(), "Save() got error") {
+		return
+	}
+
+	fileInfo, err := os.Stat(name)
+	if suite.NoErrorf(err, "os.Stat(%s) got error %v", name, err) {
+		suite.Equalf(os.FileMode(0600), fileInfo.Mode().Perm(), "saved properties file should be owner-only")
+	}
+}
+
+func (suite *PropTestSuite) TestSaveDoesNotReuseExistingPublicTempFile() {
+	if runtime.GOOS == "windows" {
+		suite.T().Skip("Unix file permission bits are not enforced on Windows")
+	}
+
+	f, err := os.CreateTemp("", "go-driver-test-*.properties")
+	if !suite.NoErrorf(err, "failed to create a temporary file for testing") {
+		return
+	}
+	name := f.Name()
+	f.Close()
+	defer os.Remove(name)
+	defer os.Remove(fmt.Sprintf("%s.tmp", name))
+
+	tmpName := fmt.Sprintf("%s.tmp", name)
+	if !suite.NoErrorf(os.WriteFile(tmpName, []byte("stale=true\n"), os.FileMode(0644)), "failed to create stale temp file") {
+		return
+	}
+	if !suite.NoErrorf(os.Chmod(tmpName, os.FileMode(0644)), "failed to chmod stale temp file") {
+		return
+	}
+
+	p, err := NewProperties(name)
+	if !suite.NoErrorf(err, "NewProperties(%s) got error %v", name, err) {
+		return
+	}
+
+	p.Put("username", "user1")
+	p.Put("password", "secret")
+	if !suite.NoErrorf(p.Save(), "Save() got error") {
+		return
+	}
+
+	fileInfo, err := os.Stat(name)
+	if suite.NoErrorf(err, "os.Stat(%s) got error %v", name, err) {
+		suite.Equalf(os.FileMode(0600), fileInfo.Mode().Perm(), "saved properties file should be owner-only")
+	}
+
+	staleTempInfo, err := os.Stat(tmpName)
+	if suite.NoErrorf(err, "os.Stat(%s) got error %v", tmpName, err) {
+		suite.Equalf(os.FileMode(0644), staleTempInfo.Mode().Perm(), "stale public temp file should not be reused")
+	}
+
+	staleTempData, err := os.ReadFile(tmpName)
+	if suite.NoErrorf(err, "os.ReadFile(%s) got error %v", tmpName, err) {
+		suite.Equalf("stale=true\n", string(staleTempData), "stale public temp file should not contain saved properties")
+	}
 }
 
 func (suite *PropTestSuite) TestConcurrency() {


### PR DESCRIPTION
KVSTORE-3323, KVSTORE-3322

file modified
-M nosqldb/internal/sdkutil/properties.go
    in Save() function fixed the issue writes updated property files with mode 0644
-M nosqldb/internal/sdkutil/properties_test.go
    created two tests TestSaveUsesPrivatePermissions() and TestSaveDoesNotReuseExistingPublicTempFile() for testing above fix
-M nosqldb/httputil/httputil.go
    in DoRequest() fixed the issue fine level logging of resp body