### PR TITLE
Fix IAM signature provider cache races

### DIFF
--- a/nosqldb/auth/iam/iam.go
+++ b/nosqldb/auth/iam/iam.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	"github.com/oracle/nosql-go-sdk/nosqldb/auth"
-	"github.com/oracle/nosql-go-sdk/nosqldb/logger"
 	"github.com/oracle/nosql-go-sdk/nosqldb/internal/sdkutil"
+	"github.com/oracle/nosql-go-sdk/nosqldb/logger"
 )
 
 const (
@@ -376,20 +376,28 @@ func (p *SignatureProvider) AuthorizationScheme() string {
 // SetDelegationToken is used to set a delegation token for the signature provider.
 // Passing an empty string will configure the provider to not use delegation.
 func (p *SignatureProvider) SetDelegationToken(delegationToken string) (*SignatureProvider, error) {
+	var signer HTTPRequestSigner
 	if delegationToken == "" {
-		p.delegationToken = delegationToken
 		// we currently don't sign the -body- of the requests
-		p.signer = RequestSignerExcludeBody(p.configProvider)
-		return p, nil
+		signer = RequestSignerExcludeBody(p.configProvider)
+	} else {
+		// check token format
+		parts := strings.Split(delegationToken, ".")
+		if len(parts) != 3 {
+			return nil, fmt.Errorf("given delegation token \"%s\" is not in valid JWT format", delegationToken)
+		}
+		// we currently don't sign the -body- of the requests
+		signer = DelegationRequestSignerExcludeBody(p.configProvider)
 	}
-	// check token format
-	parts := strings.Split(delegationToken, ".")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("given delegation token \"%s\" is not in valid JWT format", delegationToken)
-	}
+
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
 	p.delegationToken = delegationToken
-	// we currently don't sign the -body- of the requests
-	p.signer = DelegationRequestSignerExcludeBody(p.configProvider)
+	p.signer = signer
+	p.signature = ""
+	p.signatureFormattedDate = ""
+	p.signatureExpiresAt = time.Time{}
 	return p, nil
 }
 
@@ -430,33 +438,63 @@ func (p *SignatureProvider) SignHTTPRequest(req *http.Request) error {
 	// no matter what, we set the compartmentID in the header
 	req.Header.Set(requestHeaderXNoSQLCompartmentID, p.compartmentID)
 
-	// if used, set the delegation token
-	if p.delegationToken != "" {
-		req.Header.Set(requestHeaderDelegationToken, p.delegationToken)
-	}
-
 	now := time.Now()
 
 	mustHashBody := req.Header.Get("X-Nosql-Hash-Body") == "true"
 	if mustHashBody {
 		// If hashing body, skip all caching below
+		p.mutex.RLock()
+		delegationToken := p.delegationToken
+		signer := p.signer
+		p.mutex.RUnlock()
+
+		if delegationToken != "" {
+			req.Header.Set(requestHeaderDelegationToken, delegationToken)
+		} else {
+			req.Header.Del(requestHeaderDelegationToken)
+		}
+
 		signatureFormattedDate := now.UTC().Format(http.TimeFormat)
 		req.Header.Set(requestHeaderDate, signatureFormattedDate)
-		return p.signer.Sign(req)
+		return signer.Sign(req)
 	}
 
 	// use cached signature and date, if not expired and not including body hash
+	p.mutex.RLock()
 	if p.signature != "" && p.signatureExpiresAt.After(now) {
-		p.mutex.RLock()
 		defer p.mutex.RUnlock()
+		if p.delegationToken != "" {
+			req.Header.Set(requestHeaderDelegationToken, p.delegationToken)
+		} else {
+			req.Header.Del(requestHeaderDelegationToken)
+		}
+		req.Header.Set(requestHeaderDate, p.signatureFormattedDate)
+		req.Header.Set(requestHeaderAuthorization, p.signature)
+		return nil
+	}
+	p.mutex.RUnlock()
+
+	// calculate new signature
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	now = time.Now()
+	if p.signature != "" && p.signatureExpiresAt.After(now) {
+		if p.delegationToken != "" {
+			req.Header.Set(requestHeaderDelegationToken, p.delegationToken)
+		} else {
+			req.Header.Del(requestHeaderDelegationToken)
+		}
 		req.Header.Set(requestHeaderDate, p.signatureFormattedDate)
 		req.Header.Set(requestHeaderAuthorization, p.signature)
 		return nil
 	}
 
-	// calculate new signature
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
+	if p.delegationToken != "" {
+		req.Header.Set(requestHeaderDelegationToken, p.delegationToken)
+	} else {
+		req.Header.Del(requestHeaderDelegationToken)
+	}
+
 	signatureFormattedDate := now.UTC().Format(http.TimeFormat)
 	req.Header.Set(requestHeaderDate, signatureFormattedDate)
 	err := p.signer.Sign(req)

--- a/nosqldb/auth/iam/iam_test.go
+++ b/nosqldb/auth/iam/iam_test.go
@@ -16,6 +16,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -318,6 +320,153 @@ func (suite *iamTestSuite) TestNewSignatureProvider() {
 	}
 }
 
+func (suite *iamTestSuite) TestConcurrentSignatureProviderSigning() {
+	p := suite.newRawSignatureProvider()
+
+	const numGoroutines = 32
+	const numSignsPerGoroutine = 32
+
+	start := make(chan struct{})
+	errCh := make(chan error, numGoroutines*numSignsPerGoroutine)
+	var wg sync.WaitGroup
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < numSignsPerGoroutine; j++ {
+				req := newIAMSignRequest()
+				if err := p.SignHTTPRequest(req); err != nil {
+					errCh <- err
+					return
+				}
+				if req.Header.Get(requestHeaderAuthorization) == "" {
+					errCh <- fmt.Errorf("missing authorization header")
+					return
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		suite.NoError(err)
+	}
+}
+
+func (suite *iamTestSuite) TestConcurrentSignatureProviderSigningWithDelegationTokenChanges() {
+	p := suite.newRawSignatureProvider()
+
+	const numSigners = 16
+	const numIterations = 64
+
+	start := make(chan struct{})
+	errCh := make(chan error, numSigners*numIterations+numIterations)
+	var wg sync.WaitGroup
+
+	for i := 0; i < numSigners; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < numIterations; j++ {
+				req := newIAMSignRequest()
+				if err := p.SignHTTPRequest(req); err != nil {
+					errCh <- err
+					return
+				}
+				if req.Header.Get(requestHeaderAuthorization) == "" {
+					errCh <- fmt.Errorf("missing authorization header")
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < numIterations; i++ {
+			token := fmt.Sprintf("header.payload%d.signature", i)
+			if _, err := p.SetDelegationToken(token); err != nil {
+				errCh <- err
+				return
+			}
+			if i%2 == 0 {
+				if _, err := p.SetDelegationToken(""); err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}
+	}()
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		suite.NoError(err)
+	}
+}
+
+func (suite *iamTestSuite) TestDelegationTokenChangeInvalidatesCachedSignature() {
+	p := suite.newRawSignatureProvider()
+
+	req := newIAMSignRequest()
+	suite.NoError(p.SignHTTPRequest(req))
+	originalAuth := req.Header.Get(requestHeaderAuthorization)
+	suite.NotEmpty(originalAuth)
+	suite.NotEmpty(p.signature)
+
+	const tokenB = "header.payloadB.signature"
+	_, err := p.SetDelegationToken(tokenB)
+	suite.NoError(err)
+	suite.Empty(p.signature)
+	suite.Empty(p.signatureFormattedDate)
+	suite.True(p.signatureExpiresAt.IsZero())
+
+	req = newIAMSignRequest()
+	suite.NoError(p.SignHTTPRequest(req))
+	newAuth := req.Header.Get(requestHeaderAuthorization)
+	suite.Equal(tokenB, req.Header.Get(requestHeaderDelegationToken))
+	suite.NotEqual(originalAuth, newAuth)
+	suite.Contains(newAuth, requestHeaderDelegationToken)
+}
+
+func (suite *iamTestSuite) TestClearDelegationTokenInvalidatesCachedSignature() {
+	p := suite.newRawSignatureProvider()
+
+	const tokenA = "header.payloadA.signature"
+	_, err := p.SetDelegationToken(tokenA)
+	suite.NoError(err)
+
+	req := newIAMSignRequest()
+	suite.NoError(p.SignHTTPRequest(req))
+	oboAuth := req.Header.Get(requestHeaderAuthorization)
+	suite.Equal(tokenA, req.Header.Get(requestHeaderDelegationToken))
+	suite.Contains(oboAuth, requestHeaderDelegationToken)
+
+	_, err = p.SetDelegationToken("")
+	suite.NoError(err)
+	suite.Empty(p.signature)
+	suite.Empty(p.signatureFormattedDate)
+	suite.True(p.signatureExpiresAt.IsZero())
+
+	req = newIAMSignRequest()
+	req.Header.Set(requestHeaderDelegationToken, "stale.token.value")
+	suite.NoError(p.SignHTTPRequest(req))
+	nonOBOAuth := req.Header.Get(requestHeaderAuthorization)
+	suite.Empty(req.Header.Get(requestHeaderDelegationToken))
+	suite.NotEqual(oboAuth, nonOBOAuth)
+	suite.False(strings.Contains(nonOBOAuth, requestHeaderDelegationToken))
+}
+
 func getOrDefault(p *string, defaultValue string) string {
 	if p == nil {
 		return defaultValue
@@ -328,6 +477,29 @@ func getOrDefault(p *string, defaultValue string) string {
 
 func SP(s string) *string {
 	return &s
+}
+
+func (suite *iamTestSuite) newRawSignatureProvider() *SignatureProvider {
+	passphrase := ""
+	p, err := NewRawSignatureProvider(testTenancyOCID, testUserOCID, testRegion,
+		testFingerprint, testCompartmentID, testPrivateKeyConf, &passphrase)
+	suite.Require().NoError(err)
+	return p
+}
+
+func newIAMSignRequest() *http.Request {
+	body := bytes.NewBufferString("CREATE TABLE IF NOT EXISTS testData (id LONG, PRIMARY KEY(id))")
+	req, err := http.NewRequest("POST", "http://localhost:8088/V0/nosql/data", body)
+	if err != nil {
+		panic(err)
+	}
+
+	req.Header.Set("Accept", "application/octet-stream")
+	req.Header.Set("Connection", "keep-alive")
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("User-Agent", "NoSQL-GoSDK/5.0.0 (go1.12.7; linux/amd64)")
+	req.Header.Set("X-Nosql-Request-Id", "1292")
+	return req
 }
 
 func createPropFile(props testProviderInfo) (string, error) {


### PR DESCRIPTION
## Summary
Fixes IAM SignatureProvider concurrency and cache-consistency issues around cached signatures and OBO delegation token changes.

## Changes
- Protect cached signature reads with the provider mutex.
- Re-check cache state after taking the write lock.
- Protect delegation token and signer mutation with the same mutex.
- Invalidate cached signature state when delegation token changes.
- Ensure stale OBO headers are cleared when delegation is disabled.
- Add concurrent signing and delegation-token race coverage.

## Validation
- go test -count=1 ./nosqldb/auth/iam -run 'TestIAM|TestSignatureProvider'
- go test -count=1 -race ./nosqldb/auth/iam -run 'TestIAM|TestSignatureProvider'
- git diff --check