### PR TITLE
Fix on-prem access token lifecycle races

### DIFF
--- a/nosqldb/auth/kvstore/kvstore_auth.go
+++ b/nosqldb/auth/kvstore/kvstore_auth.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oracle/nosql-go-sdk/nosqldb/auth"
@@ -80,6 +81,9 @@ type AccessTokenProvider struct {
 	// isClosed represents if the provider is closed or not.
 	isClosed bool
 
+	// isClosing represents if the provider close lifecycle has started.
+	isClosing int32
+
 	// Cached token that can be reused when it is valid.
 	cachedToken *auth.Token
 
@@ -87,8 +91,9 @@ type AccessTokenProvider struct {
 	// the provider is allowed to renew the token.
 	expiryWindow time.Duration
 
-	mutex sync.RWMutex
-	wg    sync.WaitGroup
+	mutex    sync.RWMutex
+	authLock sync.Mutex
+	wg       sync.WaitGroup
 }
 
 // NewAccessTokenProviderFromFile creates an access token provider using the
@@ -96,8 +101,8 @@ type AccessTokenProvider struct {
 // the username and password that used to authenticate with the Oracle NoSQL
 // Server in the form of:
 //
-//   username=user1
-//   password=NoSql00__123456
+//	username=user1
+//	password=NoSql00__123456
 //
 // This is a variadic function that may be invoked with zero or more arguments
 // for the options parameter, but only the first argument for the options
@@ -214,7 +219,7 @@ func (p *AccessTokenProvider) AuthorizationScheme() string {
 // AuthorizationString returns an authorization string used for the specified
 // request, which is in the form of:
 //
-//   Bearer <access_token>
+//	Bearer <access_token>
 //
 // This method looks for the access token from local cache, if found, returns
 // the token, otherwise acquires the access token from remote authorization
@@ -227,28 +232,40 @@ func (p *AccessTokenProvider) AuthorizationScheme() string {
 // A cached token may not get a chance to renew if it is not retrieved by the
 // provider within the expiry window, which means it is not recently used.
 func (p *AccessTokenProvider) AuthorizationString(req auth.Request) (auth string, err error) {
-	if !p.isSecure || p.checkClosed() {
+	if !p.isSecure || p.closeStarted() {
 		return
 	}
 
 	p.mutex.RLock()
+	if p.isClosed || p.closeStarted() {
+		p.mutex.RUnlock()
+		return
+	}
 	token, ok, needRenew := p.getCachedToken()
+	if ok {
+		auth = token.AuthString()
+	}
 	p.mutex.RUnlock()
 
 	// Cached token is nil or expired.
 	if !ok {
+		if !p.beginAuthWork() {
+			return
+		}
+		defer p.wg.Done()
 		return p.login()
 	}
 
 	if needRenew {
-		p.wg.Add(1)
-		go func() {
-			defer p.wg.Done()
-			p.renewToken()
-		}()
+		if p.beginAuthWork() {
+			go func() {
+				defer p.wg.Done()
+				p.renewToken()
+			}()
+		}
 	}
 
-	return token.AuthString(), nil
+	return auth, nil
 }
 
 // SignHTTPRequest is unused in kvstore on-prem logic
@@ -263,30 +280,70 @@ func (p *AccessTokenProvider) GetLogger() *logger.Logger {
 
 // Close releases resources allocated by the provider and sets closed state for the provider.
 func (p *AccessTokenProvider) Close() error {
-	if !p.isSecure || p.checkClosed() {
+	if !p.isSecure {
 		return nil
 	}
 
-	p.wg.Wait()
+	if !atomic.CompareAndSwapInt32(&p.isClosing, 0, 1) {
+		return nil
+	}
 
 	p.mutex.Lock()
-	defer p.mutex.Unlock()
+	if p.isClosed {
+		p.mutex.Unlock()
+		return nil
+	}
+	p.isClosed = true
+	token := p.cachedToken
+	p.cachedToken = nil
+	p.mutex.Unlock()
 
-	if err := p.logout(); err != nil {
+	p.wg.Wait()
+
+	if err := p.logoutToken(token); err != nil {
 		// Log a warning message, do not return the error.
 		p.logger.Warn("%v", err)
 	}
 
-	p.isClosed = true
-	p.cachedToken = nil
 	return nil
+}
+
+// InvalidateCachedToken clears the cached bearer token so the next
+// AuthorizationString call must acquire a fresh token.
+func (p *AccessTokenProvider) InvalidateCachedToken() {
+	if !p.isSecure {
+		return
+	}
+
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	p.cachedToken = nil
 }
 
 // checkClosed checks if the provider is closed.
 func (p *AccessTokenProvider) checkClosed() bool {
 	p.mutex.RLock()
 	defer p.mutex.RUnlock()
-	return p.isClosed
+	return p.isClosed || p.closeStarted()
+}
+
+func (p *AccessTokenProvider) closeStarted() bool {
+	return atomic.LoadInt32(&p.isClosing) != 0
+}
+
+func (p *AccessTokenProvider) beginAuthWork() bool {
+	if p.closeStarted() {
+		return false
+	}
+
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	if p.isClosed || p.closeStarted() {
+		return false
+	}
+
+	p.wg.Add(1)
+	return true
 }
 
 // getCachedToken looks for the token from cache and checks if the cached token
@@ -306,35 +363,81 @@ func (p *AccessTokenProvider) getCachedToken() (token *auth.Token, ok bool, need
 // If login succeeds this method returns an authorization string that contains
 // an access token retrieved from server.
 func (p *AccessTokenProvider) login() (auth string, err error) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
+	p.authLock.Lock()
+	defer p.authLock.Unlock()
 
-	token, err := p.doRequest(loginService, p.basicAuth)
+	p.mutex.RLock()
+	if p.isClosed || p.closeStarted() {
+		p.mutex.RUnlock()
+		return
+	}
+	token, ok, _ := p.getCachedToken()
+	if ok {
+		auth = token.AuthString()
+		p.mutex.RUnlock()
+		return
+	}
+	p.mutex.RUnlock()
+
+	token, err = p.doRequest(loginService, p.basicAuth)
 	if err != nil {
 		return
 	}
 
+	auth = token.AuthString()
+
+	p.mutex.Lock()
+	if p.isClosed || p.closeStarted() {
+		p.mutex.Unlock()
+		if err = p.logoutToken(token); err != nil {
+			p.logger.Warn("%v", err)
+			err = nil
+		}
+		return "", nil
+	}
 	p.cachedToken = token
-	return token.AuthString(), nil
+	p.mutex.Unlock()
+	return auth, nil
 }
 
 // renewToken attempts to renew the token that currently in use.
 func (p *AccessTokenProvider) renewToken() error {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
+	p.authLock.Lock()
+	defer p.authLock.Unlock()
 
-	oldToken, ok, _ := p.getCachedToken()
-	if !ok {
+	p.mutex.RLock()
+	if p.isClosed || p.closeStarted() {
+		p.mutex.RUnlock()
 		return nil
 	}
+	oldToken, ok, _ := p.getCachedToken()
+	if !ok {
+		p.mutex.RUnlock()
+		return nil
+	}
+	oldAuth := oldToken.AuthString()
+	p.mutex.RUnlock()
 
-	token, err := p.doRequest(renewService, oldToken.AuthString())
+	token, err := p.doRequest(renewService, oldAuth)
 	if err != nil {
 		p.logger.Warn("%v", err)
 		return err
 	}
 
+	p.mutex.Lock()
+	if p.isClosed || p.closeStarted() {
+		p.mutex.Unlock()
+		if err = p.logoutToken(token); err != nil {
+			p.logger.Warn("%v", err)
+		}
+		return nil
+	}
+	if p.cachedToken == nil || p.cachedToken.AuthString() != oldAuth {
+		p.mutex.Unlock()
+		return nil
+	}
 	p.cachedToken = token
+	p.mutex.Unlock()
 	return nil
 }
 
@@ -342,6 +445,14 @@ func (p *AccessTokenProvider) renewToken() error {
 func (p *AccessTokenProvider) logout() error {
 	token, ok, _ := p.getCachedToken()
 	if !ok {
+		return nil
+	}
+
+	return p.logoutToken(token)
+}
+
+func (p *AccessTokenProvider) logoutToken(token *auth.Token) error {
+	if token == nil || token.Expired() {
 		return nil
 	}
 
@@ -353,8 +464,12 @@ func (p *AccessTokenProvider) logout() error {
 // service using the authorization string.
 func (p *AccessTokenProvider) doRequest(service, auth string) (token *auth.Token, err error) {
 	url := p.endpoint + service
-	p.reqHeaders["Authorization"] = auth
-	resp, err := httputil.DoRequest(context.Background(), p.httpClient, p.timeout, http.MethodGet, url, nil, p.reqHeaders, p.logger)
+	headers := make(map[string]string, len(p.reqHeaders)+1)
+	for k, v := range p.reqHeaders {
+		headers[k] = v
+	}
+	headers["Authorization"] = auth
+	resp, err := httputil.DoRequest(context.Background(), p.httpClient, p.timeout, http.MethodGet, url, nil, headers, p.logger)
 	if err != nil {
 		return
 	}

--- a/nosqldb/auth/kvstore/kvstore_auth_test.go
+++ b/nosqldb/auth/kvstore/kvstore_auth_test.go
@@ -381,6 +381,59 @@ func (suite *AuthTestSuite) TestAuthorizationString() {
 	wg.Wait()
 }
 
+func (suite *AuthTestSuite) TestInvalidateCachedToken() {
+	p, err := NewAccessTokenProvider("TestUser01", []byte("NoSql00__123456"))
+	suite.Require().NoError(err)
+
+	p.cachedToken = auth.NewToken("rejected-token", "", time.Hour)
+	p.InvalidateCachedToken()
+	suite.Nil(p.cachedToken)
+}
+
+func (suite *AuthTestSuite) TestConcurrentAuthorizationStringAndClose() {
+	p, err := NewAccessTokenProvider("TestUser01", []byte("NoSql00__123456"), auth.ProviderOptions{
+		HTTPClient: httputil.DefaultHTTPClient,
+		Logger:     testLogger,
+		Timeout:    time.Millisecond,
+	})
+	suite.Require().NoError(err)
+
+	const numAuthCalls = 32
+	start := make(chan struct{})
+	errCh := make(chan error, numAuthCalls+1)
+	var wg sync.WaitGroup
+
+	for i := 0; i < numAuthCalls; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = p.AuthorizationString(nil)
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		errCh <- p.Close()
+	}()
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		suite.NoError(err)
+	}
+	suite.True(p.checkClosed())
+	suite.Nil(p.cachedToken)
+
+	authStr, err := p.AuthorizationString(nil)
+	suite.NoError(err)
+	suite.Empty(authStr)
+}
+
 func (suite *AuthTestSuite) getAuthStringTest(testName string,
 	server *mockAuthServer, p *AccessTokenProvider) {
 

--- a/nosqldb/client.go
+++ b/nosqldb/client.go
@@ -113,6 +113,10 @@ type Client struct {
 	isOKResponseProcessed int32
 }
 
+type cachedAuthTokenInvalidator interface {
+	InvalidateCachedToken()
+}
+
 var (
 	errNilRequest       = nosqlerr.NewIllegalArgument("request must be non-nil")
 	errNilContext       = nosqlerr.NewIllegalArgument("nil context")
@@ -1444,11 +1448,20 @@ func (c *Client) updateTableLimiters(tableName string) {
 func (c *Client) handleError(err error, req Request, numRetries int) (shouldRetry bool) {
 	if isRetryableError(err) {
 		c.logger.Fine("got retryable error: %v", err)
+		if nosqlerr.Is(err, nosqlerr.RetryAuthentication) {
+			c.invalidateCachedAuthToken()
+		}
 		return c.handleRetry(err, req, uint(numRetries))
 	}
 
 	c.logger.Fine("got non-retryable error: %v", err)
 	return false
+}
+
+func (c *Client) invalidateCachedAuthToken() {
+	if p, ok := c.AuthorizationProvider.(cachedAuthTokenInvalidator); ok {
+		p.InvalidateCachedToken()
+	}
 }
 
 // handleRetry checks if the specified request should continue to retry upon

--- a/nosqldb/client_test.go
+++ b/nosqldb/client_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -288,6 +289,27 @@ func TestExecuteErrorHandling(t *testing.T) {
 			assert.Equalf(t, expectErr, e, prefixMsg+"got unexpected error")
 		}
 	}
+}
+
+func TestHandleErrorInvalidatesCachedAuthTokenOnRetryAuthentication(t *testing.T) {
+	client, err := newMockClient()
+	require.NoErrorf(t, err, "failed to create client, got error %v.", err)
+
+	retryHandler, err := NewDefaultRetryHandler(1, time.Millisecond)
+	require.NoError(t, err)
+	client.RetryHandler = retryHandler
+
+	req := &GetRequest{
+		TableName: "T1",
+		Key:       types.NewMapValue(map[string]interface{}{"id": 1}),
+	}
+	err = nosqlerr.New(nosqlerr.RetryAuthentication, "retry authentication")
+
+	shouldRetry := client.handleError(err, req, 0)
+	require.True(t, shouldRetry)
+
+	authProvider := client.AuthorizationProvider.(*DummyAccessTokenProvider)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&authProvider.invalidations))
 }
 
 func newMockClient() (*Client, error) {

--- a/nosqldb/util_test.go
+++ b/nosqldb/util_test.go
@@ -9,6 +9,7 @@ package nosqldb
 
 import (
 	"net/http"
+	"sync/atomic"
 
 	"github.com/oracle/nosql-go-sdk/nosqldb/auth"
 	"github.com/oracle/nosql-go-sdk/nosqldb/logger"
@@ -24,7 +25,8 @@ func equalError(a, b error) bool {
 // DummyAccessTokenProvider represents a dummy access token provider, which is used by tests.
 // It implements the AccessTokenProvider interface.
 type DummyAccessTokenProvider struct {
-	TenantID string
+	TenantID      string
+	invalidations int32
 }
 
 func (p *DummyAccessTokenProvider) AuthorizationScheme() string {
@@ -37,6 +39,10 @@ func (p *DummyAccessTokenProvider) AuthorizationString(req auth.Request) (string
 
 func (p *DummyAccessTokenProvider) Close() error {
 	return nil
+}
+
+func (p *DummyAccessTokenProvider) InvalidateCachedToken() {
+	atomic.AddInt32(&p.invalidations, 1)
 }
 
 func (p DummyAccessTokenProvider) SignHTTPRequest(req *http.Request) error {


### PR DESCRIPTION
## Summary
Fixes on-prem AccessTokenProvider lifecycle issues around RetryAuthentication and concurrent Close/AuthorizationString behavior.

## Changes
- Invalidate cached bearer token when RetryAuthentication is handled for retry.
- Add AccessTokenProvider cache invalidation support.
- Guard token cache, login/renew, and close lifecycle with synchronization.
- Prevent login/renew from repopulating cachedToken after close begins.
- Ensure AuthorizationString returns empty auth after provider close.
- Add tests for RetryAuthentication invalidation and concurrent AuthorizationString/Close.

## Validation
- go test -count=1 ./nosqldb/auth/kvstore -run 'TestAuth|TestAccessTokenProvider'
- go test -count=1 ./nosqldb/auth/kvstore
- go test -count=1 -race ./nosqldb/auth/kvstore -run 'TestAuth/TestInvalidateCachedToken|TestAuth/TestConcurrentAuthorizationStringAndClose'
- go test -count=1 ./nosqldb -run 'TestHandleErrorInvalidatesCachedAuthTokenOnRetryAuthentication'
- git diff --check