### PR TITLE
Fix federation auth retry request body reuse

### DIFF
--- a/nosqldb/auth/iam/federation_client.go
+++ b/nosqldb/auth/iam/federation_client.go
@@ -363,12 +363,15 @@ func (c *x509FederationClient) makeHTTPRequest(request *x509FederationRequest) (
 		return nil, err
 	}
 
-	bodyBytes := bytes.NewReader(rawJSON)
+	newBody := func() io.ReadCloser {
+		return io.NopCloser(bytes.NewReader(rawJSON))
+	}
 	httpRequest.Header.Set("Content-Length", strconv.Itoa(len(rawJSON)))
 	httpRequest.Header.Set("Content-Type", "application/json")
-	httpRequest.Body = io.NopCloser(bodyBytes)
+	httpRequest.ContentLength = int64(len(rawJSON))
+	httpRequest.Body = newBody()
 	httpRequest.GetBody = func() (io.ReadCloser, error) {
-		return io.NopCloser(bodyBytes), nil
+		return newBody(), nil
 	}
 
 	return &httpRequest, nil
@@ -376,14 +379,15 @@ func (c *x509FederationClient) makeHTTPRequest(request *x509FederationRequest) (
 
 func (c *x509FederationClient) getSecurityToken() (securityToken, error) {
 	request := c.makeX509FederationRequest()
-	httpRequest, err := c.makeHTTPRequest(request)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make http request: %s", err.Error())
-	}
-
 	var httpResponse *http.Response
+	var err error
 
 	for retry := 0; retry < 5; retry++ {
+		httpRequest, err := c.makeHTTPRequest(request)
+		if err != nil {
+			return nil, fmt.Errorf("failed to make http request: %s", err.Error())
+		}
+
 		if httpResponse, err = c.authClient.Call(httpRequest); err == nil {
 			break
 		}

--- a/nosqldb/auth/iam/federation_client_test.go
+++ b/nosqldb/auth/iam/federation_client_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -123,6 +124,82 @@ func TestX509FederationClient_RenewSecurityToken(t *testing.T) {
 	mockSessionKeySupplier.AssertExpectations(t)
 	mockLeafCertificateRetriever.AssertExpectations(t)
 	mockIntermediateCertificateRetriever.AssertExpectations(t)
+}
+
+func TestX509FederationClient_GetBodyReturnsFreshReader(t *testing.T) {
+	federationClient := &x509FederationClient{}
+	federationClient.authClient, _ = newAuthClient(whateverRegion, federationClient)
+	federationClient.authClient.Host = "https://auth.example.com"
+	federationClient.authClient.BasePath = ""
+
+	request := &x509FederationRequest{
+		Certificate:              "cert",
+		IntermediateCertificates: []string{"intermediate"},
+		PublicKey:                "public-key",
+		FingerprintAlgorithm:     "SHA256",
+		Purpose:                  "DEFAULT",
+	}
+
+	httpRequest, err := federationClient.makeHTTPRequest(request)
+	assert.NoError(t, err)
+
+	body1, err := io.ReadAll(httpRequest.Body)
+	assert.NoError(t, err)
+
+	bodyReader2, err := httpRequest.GetBody()
+	assert.NoError(t, err)
+	body2, err := io.ReadAll(bodyReader2)
+	assert.NoError(t, err)
+
+	bodyReader3, err := httpRequest.GetBody()
+	assert.NoError(t, err)
+	body3, err := io.ReadAll(bodyReader3)
+	assert.NoError(t, err)
+
+	expectedBody := `{"certificate":"cert","intermediateCertificates":["intermediate"],"publicKey":"public-key","fingerprintAlgorithm":"SHA256","purpose":"DEFAULT"}`
+	assert.Equal(t, expectedBody, string(body1))
+	assert.Equal(t, expectedBody, string(body2))
+	assert.Equal(t, expectedBody, string(body3))
+	assert.Equal(t, int64(len(expectedBody)), httpRequest.ContentLength)
+}
+
+func TestX509FederationClient_RetryUsesOriginalRequestBody(t *testing.T) {
+	expectedBody := expectedX509FederationRequestBody()
+	transport := &retryBodyTransport{
+		t:            t,
+		expectedBody: expectedBody,
+	}
+
+	mockSessionKeySupplier := new(mockSessionKeySupplier)
+	mockSessionKeySupplier.On("PublicKeyPemRaw").Return([]byte(sessionPublicKeyPem))
+
+	mockLeafCertificateRetriever := new(mockCertificateRetriever)
+	mockLeafCertificateRetriever.On("CertificatePemRaw").Return([]byte(leafCertPem))
+	mockLeafCertificateRetriever.On("Certificate").Return(parseCertificate(leafCertPem))
+	mockLeafCertificateRetriever.On("PrivateKey").Return(parsePrivateKey(leafCertPrivateKeyPem))
+
+	mockIntermediateCertificateRetriever := new(mockCertificateRetriever)
+	mockIntermediateCertificateRetriever.On("CertificatePemRaw").Return([]byte(intermediateCertPem))
+
+	federationClient := &x509FederationClient{
+		tenancyID:                         tenancyID,
+		sessionKeySupplier:                mockSessionKeySupplier,
+		leafCertificateRetriever:          mockLeafCertificateRetriever,
+		intermediateCertificateRetrievers: []x509CertificateRetriever{mockIntermediateCertificateRetriever},
+	}
+	federationClient.authClient, _ = newAuthClient(whateverRegion, federationClient)
+	federationClient.authClient.Host = "https://auth.example.com"
+	federationClient.authClient.BasePath = ""
+	federationClient.authClient.HTTPClient = &http.Client{
+		Transport: transport,
+	}
+
+	token, err := federationClient.getSecurityToken()
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedSecurityToken, token.String())
+	}
+	assert.Equal(t, []string{expectedBody, expectedBody}, transport.bodies)
+	assert.Equal(t, 2, transport.attempts)
 }
 
 func TestX509FederationClient_GetCachedSecurityToken(t *testing.T) {
@@ -343,6 +420,37 @@ func parsePrivateKey(privateKeyPem string) *rsa.PrivateKey {
 	block, _ := pem.Decode([]byte(privateKeyPem))
 	key, _ := x509.ParsePKCS1PrivateKey(block.Bytes)
 	return key
+}
+
+func expectedX509FederationRequestBody() string {
+	return fmt.Sprintf(`{"certificate":"%s","intermediateCertificates":["%s"],"publicKey":"%s","fingerprintAlgorithm":"SHA256","purpose":"DEFAULT"}`,
+		leafCertBodyNoNewLine, intermediateCertBodyNoNewLine, sessionPublicKeyBodyNoNewLine)
+}
+
+type retryBodyTransport struct {
+	t            *testing.T
+	expectedBody string
+	attempts     int
+	bodies       []string
+}
+
+func (rt *retryBodyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.attempts++
+	body, err := io.ReadAll(req.Body)
+	assert.NoError(rt.t, err)
+	rt.bodies = append(rt.bodies, string(body))
+	assert.Equal(rt.t, rt.expectedBody, string(body))
+
+	if rt.attempts == 1 {
+		return nil, fmt.Errorf("transient auth service error")
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(`{"token":"%s"}`, expectedSecurityToken))),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
 }
 
 const (


### PR DESCRIPTION
## Summary
Fixes IAM federation auth retry behavior so retry attempts do not reuse a consumed HTTP request body.

## Changes
- Build federation auth requests from stable raw JSON bytes.
- Ensure `GetBody` returns a fresh reader every time.
- Ensure retry attempts send the original JSON body instead of an empty body.
- Add regression tests for `GetBody` freshness and retry body preservation.

## Validation
- go test -count=1 ./nosqldb/auth/iam -run 'TestFederation|TestInstance|TestUrlBased|TestResource'
- go test -count=1 -race ./nosqldb/auth/iam -run 'TestX509FederationClient_(GetBodyReturnsFreshReader|RetryUsesOriginalRequestBody)'
- git diff --check