### PR TITLE
Align retryable error handling with documented behavior

### DIFF
--- a/nosqldb/client.go
+++ b/nosqldb/client.go
@@ -1763,6 +1763,14 @@ func (c *Client) processNotOKResponse(data []byte, statusCode int) error {
 		return fmt.Errorf("error response: %s", string(data))
 	}
 
+	if statusCode == http.StatusServiceUnavailable {
+		msg := fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode))
+		if len(data) > 0 {
+			msg = string(data)
+		}
+		return nosqlerr.New(nosqlerr.ServiceUnavailable, "error response: %s", msg)
+	}
+
 	return fmt.Errorf("error response: %d %s", statusCode, http.StatusText(statusCode))
 }
 

--- a/nosqldb/client_test.go
+++ b/nosqldb/client_test.go
@@ -312,6 +312,60 @@ func TestHandleErrorInvalidatesCachedAuthTokenOnRetryAuthentication(t *testing.T
 	assert.Equal(t, int32(1), atomic.LoadInt32(&authProvider.invalidations))
 }
 
+func TestExecuteRetryableErrorAlignment(t *testing.T) {
+	client, err := newMockClient()
+	require.NoErrorf(t, err, "failed to create client, got error %v.", err)
+	client.SetSerialVersion(3)
+
+	retryHandler, err := NewDefaultRetryHandler(1, time.Millisecond)
+	require.NoError(t, err)
+	client.RetryHandler = retryHandler
+
+	getReq := &GetRequest{
+		TableName: "T1",
+		Key:       types.NewMapValue(map[string]interface{}{"id": 1}),
+		Timeout:   time.Second,
+	}
+	exec := &sequenceExecutor{
+		injectErrors: []error{
+			mockErr{errCode: http.StatusServiceUnavailable, msg: "service unavailable"},
+			nosqlerr.New(nosqlerr.TableNotFound, "expected after retry"),
+		},
+	}
+	client.executor = exec
+
+	_, err = client.Get(getReq)
+	assert.Truef(t, nosqlerr.Is(err, nosqlerr.TableNotFound), "expected TableNotFound after ServiceUnavailable retry, got %v", err)
+	assert.Equal(t, 2, exec.calls)
+
+	getReq = &GetRequest{
+		TableName: "T1",
+		Key:       types.NewMapValue(map[string]interface{}{"id": 1}),
+		Timeout:   time.Second,
+	}
+	exec = &sequenceExecutor{
+		injectErrors: []error{
+			nosqlerr.New(nosqlerr.SizeLimitExceeded, "size limit exceeded"),
+			nosqlerr.New(nosqlerr.TableNotFound, "unexpected retry"),
+		},
+	}
+	client.executor = exec
+
+	_, err = client.Get(getReq)
+	assert.Truef(t, nosqlerr.Is(err, nosqlerr.SizeLimitExceeded), "expected SizeLimitExceeded without retry, got %v", err)
+	assert.Equal(t, 1, exec.calls)
+}
+
+func TestProcessNotOKResponseMapsServiceUnavailable(t *testing.T) {
+	client, err := newMockClient()
+	require.NoErrorf(t, err, "failed to create client, got error %v.", err)
+
+	err = client.processNotOKResponse([]byte("temporarily unavailable"), http.StatusServiceUnavailable)
+	if assert.Truef(t, nosqlerr.Is(err, nosqlerr.ServiceUnavailable), "expected ServiceUnavailable, got %v", err) {
+		assert.True(t, err.(*nosqlerr.Error).Retryable())
+	}
+}
+
 func newMockClient() (*Client, error) {
 	authProvider := &DummyAccessTokenProvider{
 		TenantID: "TestTenantId",
@@ -327,6 +381,38 @@ func newMockClient() (*Client, error) {
 	}
 
 	return client, nil
+}
+
+type sequenceExecutor struct {
+	injectErrors []error
+	calls        int
+}
+
+func (m *sequenceExecutor) Do(req *http.Request) (*http.Response, error) {
+	if m.calls >= len(m.injectErrors) {
+		m.calls++
+		return nil, fmt.Errorf("unexpected retry attempt %d", m.calls)
+	}
+
+	injectErr := m.injectErrors[m.calls]
+	m.calls++
+	switch e := injectErr.(type) {
+	case *nosqlerr.Error:
+		resp := (&mockExecutor{}).generateResponse(e, req)
+		return resp, nil
+	case mockErr:
+		if e.errCode != 0 {
+			resp := (&mockExecutor{}).generateResponse(e, req)
+			return resp, nil
+		}
+		return nil, &url.Error{
+			Op:  req.Method,
+			URL: req.URL.String(),
+			Err: e,
+		}
+	default:
+		return nil, injectErr
+	}
 }
 
 type mockExecutor struct {

--- a/nosqldb/nosqlerr/errors.go
+++ b/nosqldb/nosqlerr/errors.go
@@ -68,12 +68,12 @@ var retryableErrors map[ErrorCode]bool = map[ErrorCode]bool{
 	SecurityInfoUnavailable: true,
 	RetryAuthentication:     true,
 	ServerError:             true,
+	ServiceUnavailable:      true,
 	TableBusy:               true,
 	TableNotReady:           true,
 	OperationLimitExceeded:  true,
 	ReadLimitExceeded:       true,
 	WriteLimitExceeded:      true,
-	SizeLimitExceeded:       true,
 }
 
 // NewIllegalArgument creates an IllegalArgument error with the specified message.

--- a/nosqldb/nosqlerr/errors_test.go
+++ b/nosqldb/nosqlerr/errors_test.go
@@ -56,6 +56,14 @@ func (suite *NoSQLErrorsTestSuite) TestNewErrors() {
 	suite.Falsef(e.Retryable(), "RequestTimeout error should not be retryable")
 }
 
+func (suite *NoSQLErrorsTestSuite) TestDocumentedRetryableErrors() {
+	e := New(SizeLimitExceeded, "table size limit exceeded")
+	suite.Falsef(e.Retryable(), "SizeLimitExceeded error should not be retryable")
+
+	e = New(ServiceUnavailable, "service is unavailable")
+	suite.Truef(e.Retryable(), "ServiceUnavailable error should be retryable")
+}
+
 func (suite *NoSQLErrorsTestSuite) TestIsErrors() {
 	e1 := NewIllegalArgument("illegal arguments: Arg1")
 	e2 := New(TableNotFound, "table T1 does not exist")


### PR DESCRIPTION
## Summary
Aligns retryable error classification with documented SDK behavior.

## Changes
- Mark `SizeLimitExceeded` as non-retryable.
- Mark `ServiceUnavailable` as retryable.
- Map plain HTTP 503 responses to `nosqlerr.ServiceUnavailable`.
- Add client retry-flow coverage showing:
  - ServiceUnavailable is retried when the request type allows retry.
  - SizeLimitExceeded is not retried.

## Validation
- go test -count=1 ./nosqldb/nosqlerr
- go test -count=1 ./nosqldb -run 'TestExecuteRetryableErrorAlignment|TestProcessNotOKResponseMapsServiceUnavailable|TestHandleErrorInvalidatesCachedAuthTokenOnRetryAuthentication'
- go test -count=1 ./nosqldb ./nosqldb/nosqlerr
- git diff --check