### PR TITLE
Enforce request timeout across retries and waits

### DIFF
--- a/nosqldb/client.go
+++ b/nosqldb/client.go
@@ -1057,6 +1057,33 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 	}
 
 	startTime := time.Now()
+	remainingTimeout := func(timeout time.Duration) time.Duration {
+		if timeout <= 0 {
+			return 0
+		}
+		return timeout - time.Since(startTime)
+	}
+	checkDeadline := func(timeout time.Duration, cause error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if timeout > 0 && remainingTimeout(timeout) <= 0 {
+			return nosqlerr.NewWithCause(nosqlerr.RequestTimeout, cause,
+				"request timed out after %d attempt(s). Timeout: %v", numRetries+1, timeout)
+		}
+		return nil
+	}
+	contextWithRemainingTimeout := func(timeout time.Duration, cause error) (context.Context, context.CancelFunc, error) {
+		if err := checkDeadline(timeout, cause); err != nil {
+			return nil, nil, err
+		}
+		if timeout <= 0 {
+			reqCtx, cancel := context.WithCancel(ctx)
+			return reqCtx, cancel, nil
+		}
+		reqCtx, cancel := context.WithTimeout(ctx, remainingTimeout(timeout))
+		return reqCtx, cancel, nil
+	}
 
 	for {
 
@@ -1068,9 +1095,8 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 				timeout = reqTimeout
 			}
 
-			if time.Since(startTime) > timeout {
-				return nil, nosqlerr.NewWithCause(nosqlerr.RequestTimeout, err,
-					"request timed out after %d attempt(s). Timeout: %v", numRetries+1, timeout)
+			if deadlineErr := checkDeadline(timeout, err); deadlineErr != nil {
+				return nil, deadlineErr
 			}
 
 			if readLimiter != nil && nosqlerr.Is(err, nosqlerr.ReadLimitExceeded) {
@@ -1109,8 +1135,22 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 				if err != nil {
 					return nil, err
 				}
-			} else if !c.handleError(err, req, numThrottleRetries) {
-				return nil, err
+			} else {
+				retryCtx, retryCancel, deadlineErr := contextWithRemainingTimeout(timeout, err)
+				if deadlineErr != nil {
+					return nil, deadlineErr
+				}
+				shouldRetry, retryErr := c.handleError(retryCtx, err, req, numThrottleRetries)
+				retryCancel()
+				if retryErr != nil {
+					if deadlineErr = checkDeadline(timeout, err); deadlineErr != nil {
+						return nil, deadlineErr
+					}
+					return nil, retryErr
+				}
+				if !shouldRetry {
+					return nil, err
+				}
 			}
 
 			if isSecErr {
@@ -1128,33 +1168,45 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 
 		// Before executing request: wait for rate limiter(s) to go below limit
 		if readLimiter != nil && checkReadUnits {
+			if deadlineErr := checkDeadline(reqTimeout, err); deadlineErr != nil {
+				return nil, deadlineErr
+			}
 			// wait for read limiter to come below the limit
-			timeout = reqTimeout - time.Since(startTime)
+			timeout = remainingTimeout(reqTimeout)
 			if timeout <= 0 {
 				if !readLimiter.TryConsumeUnits(0) {
 					return nil, nosqlerr.New(nosqlerr.RequestTimeout, "Could not execute request due to read rate limiting")
 				}
 			} else {
 				// note this may sleep for a while
-				ms, err := readLimiter.ConsumeUnitsWithTimeout(0, timeout, false)
-				if err != nil {
+				ms, limiterErr := c.consumeLimiterUnitsWithContext(ctx, readLimiter, 0, timeout, false)
+				if limiterErr != nil {
+					if deadlineErr := checkDeadline(reqTimeout, limiterErr); deadlineErr != nil {
+						return nil, deadlineErr
+					}
 					return nil, nosqlerr.New(nosqlerr.RequestTimeout, "Could not execute request due to read rate limiting")
 				}
 				rateDelayedTime += ms
 			}
 		}
 		if writeLimiter != nil && checkWriteUnits {
+			if deadlineErr := checkDeadline(reqTimeout, err); deadlineErr != nil {
+				return nil, deadlineErr
+			}
 			// wait for write limiter to come below the limit
 			// note this may sleep for a while
-			timeout = reqTimeout - time.Since(startTime)
+			timeout = remainingTimeout(reqTimeout)
 			if timeout <= 0 {
 				if !writeLimiter.TryConsumeUnits(0) {
 					return nil, nosqlerr.New(nosqlerr.RequestTimeout, "Could not execute request due to write rate limiting")
 				}
 			} else {
 				// note this may sleep for a while
-				ms, err := writeLimiter.ConsumeUnitsWithTimeout(0, timeout, false)
-				if err != nil {
+				ms, limiterErr := c.consumeLimiterUnitsWithContext(ctx, writeLimiter, 0, timeout, false)
+				if limiterErr != nil {
+					if deadlineErr := checkDeadline(reqTimeout, limiterErr); deadlineErr != nil {
+						return nil, deadlineErr
+					}
 					return nil, nosqlerr.New(nosqlerr.RequestTimeout, "Could not execute request due to write rate limiting")
 				}
 				rateDelayedTime += ms
@@ -1238,7 +1290,10 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 			}
 		}
 
-		reqCtx, reqCancel := context.WithTimeout(ctx, reqTimeout)
+		reqCtx, reqCancel, deadlineErr := contextWithRemainingTimeout(reqTimeout, err)
+		if deadlineErr != nil {
+			return nil, deadlineErr
+		}
 		httpReq = httpReq.WithContext(reqCtx)
 		httpResp, err = c.executor.Do(httpReq)
 		if err != nil {
@@ -1268,12 +1323,12 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 		// limiters, possibly delaying return
 		used, _ := result.ConsumedCapacity()
 		if used.ReadUnits > 0 && readLimiter != nil {
-			timeout = reqTimeout - time.Since(startTime)
-			rateDelayedTime += c.consumeLimiterUnits(readLimiter, int64(used.ReadUnits), timeout)
+			timeout = remainingTimeout(reqTimeout)
+			rateDelayedTime += c.consumeLimiterUnits(ctx, readLimiter, int64(used.ReadUnits), timeout)
 		}
 		if used.WriteKB > 0 && writeLimiter != nil {
-			timeout = reqTimeout - time.Since(startTime)
-			rateDelayedTime += c.consumeLimiterUnits(writeLimiter, int64(used.WriteKB), timeout)
+			timeout = remainingTimeout(reqTimeout)
+			rateDelayedTime += c.consumeLimiterUnits(ctx, writeLimiter, int64(used.WriteKB), timeout)
 		}
 		result.Delayed().setRateLimitTime(rateDelayedTime)
 		result.Delayed().setRetryTime(req.GetRetryTime())
@@ -1351,7 +1406,7 @@ func (c *Client) backgroundUpdateLimiters(tableName string) {
 
 // Comsume rate limiter units after successful operation.
 // return the duration delayed due to rate limiting
-func (c *Client) consumeLimiterUnits(rl common.RateLimiter, units int64, timeout time.Duration) time.Duration {
+func (c *Client) consumeLimiterUnits(ctx context.Context, rl common.RateLimiter, units int64, timeout time.Duration) time.Duration {
 
 	if rl == nil || units <= 0 {
 		return 0
@@ -1363,8 +1418,17 @@ func (c *Client) consumeLimiterUnits(rl common.RateLimiter, units int64, timeout
 	}
 
 	// "true" == "consume units, even on timeout"
-	ret, _ := rl.ConsumeUnitsWithTimeout(units, timeout, true)
+	ret, _ := c.consumeLimiterUnitsWithContext(ctx, rl, units, timeout, true)
 	return ret
+}
+
+func (c *Client) consumeLimiterUnitsWithContext(ctx context.Context, rl common.RateLimiter, units int64,
+	timeout time.Duration, alwaysConsume bool) (time.Duration, error) {
+
+	if ctxLimiter, ok := rl.(common.ContextRateLimiter); ok {
+		return ctxLimiter.ConsumeUnitsWithContext(ctx, units, timeout, alwaysConsume)
+	}
+	return rl.ConsumeUnitsWithTimeout(units, timeout, alwaysConsume)
 }
 
 func (c *Client) updateRateLimiters(tableName string, limits TableLimits) bool {
@@ -1445,17 +1509,17 @@ func (c *Client) updateTableLimiters(tableName string) {
 // If the error is retryable, this method calls the RetryHandler configured for
 // the client to proceed with retry handling. Otherwise, it returns false
 // indicating the request should not be retried.
-func (c *Client) handleError(err error, req Request, numRetries int) (shouldRetry bool) {
+func (c *Client) handleError(ctx context.Context, err error, req Request, numRetries int) (shouldRetry bool, delayErr error) {
 	if isRetryableError(err) {
 		c.logger.Fine("got retryable error: %v", err)
 		if nosqlerr.Is(err, nosqlerr.RetryAuthentication) {
 			c.invalidateCachedAuthToken()
 		}
-		return c.handleRetry(err, req, uint(numRetries))
+		return c.handleRetry(ctx, err, req, uint(numRetries))
 	}
 
 	c.logger.Fine("got non-retryable error: %v", err)
-	return false
+	return false, nil
 }
 
 func (c *Client) invalidateCachedAuthToken() {
@@ -1468,9 +1532,9 @@ func (c *Client) invalidateCachedAuthToken() {
 // receiving the specified error and having attempted the specified number
 // of retries. If the request should retry, handleRetry will pause the current
 // goroutine for a duration according to the RetryHandler configurations.
-func (c *Client) handleRetry(err error, req Request, numRetries uint) bool {
+func (c *Client) handleRetry(ctx context.Context, err error, req Request, numRetries uint) (bool, error) {
 	if c.RetryHandler == nil {
-		return false
+		return false, nil
 	}
 
 	c.logger.LogWithFn(logger.Fine, func() string {
@@ -1479,15 +1543,24 @@ func (c *Client) handleRetry(err error, req Request, numRetries uint) bool {
 	})
 
 	if c.RetryHandler.ShouldRetry(req, numRetries, err) {
-		c.RetryHandler.Delay(req, numRetries, err)
-		return true
+		if ctxRetryHandler, ok := c.RetryHandler.(ContextRetryHandler); ok {
+			if err := ctxRetryHandler.DelayWithContext(ctx, req, numRetries, err); err != nil {
+				return false, err
+			}
+		} else {
+			c.RetryHandler.Delay(req, numRetries, err)
+			if err := ctx.Err(); err != nil {
+				return false, err
+			}
+		}
+		return true, nil
 	}
 
 	if maxRetries := c.RetryHandler.MaxNumRetries(); numRetries >= maxRetries {
 		c.logger.Fine("number of retries has reached the maximum of %d", maxRetries)
 	}
 
-	return false
+	return false, nil
 }
 
 // getAuthString returns an authorization string for the specified request.

--- a/nosqldb/client_test.go
+++ b/nosqldb/client_test.go
@@ -9,6 +9,8 @@ package nosqldb
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/oracle/nosql-go-sdk/nosqldb/common"
 	"github.com/oracle/nosql-go-sdk/nosqldb/internal/proto/binary"
 	"github.com/oracle/nosql-go-sdk/nosqldb/nosqlerr"
 	"github.com/oracle/nosql-go-sdk/nosqldb/types"
@@ -67,7 +70,7 @@ func TestExecuteErrorHandling(t *testing.T) {
 				mockErr{msg: "mock retryable error 3", isTemp: true},
 			},
 			req:              getReq,
-			timeout:          2 * time.Second,
+			timeout:          2200 * time.Millisecond,
 			expectTimeoutErr: true,
 			maxNumRetries:    3,
 			retryInterval:    time.Second,
@@ -172,7 +175,7 @@ func TestExecuteErrorHandling(t *testing.T) {
 				nosqlerr.New(nosqlerr.ReadLimitExceeded, "retryable ReadLimitExceeded error 3"),
 			},
 			req:              getReq,
-			timeout:          3 * time.Second,
+			timeout:          3200 * time.Millisecond,
 			expectTimeoutErr: true,
 			maxNumRetries:    5,
 			retryInterval:    time.Second,
@@ -305,11 +308,140 @@ func TestHandleErrorInvalidatesCachedAuthTokenOnRetryAuthentication(t *testing.T
 	}
 	err = nosqlerr.New(nosqlerr.RetryAuthentication, "retry authentication")
 
-	shouldRetry := client.handleError(err, req, 0)
+	shouldRetry, retryErr := client.handleError(context.Background(), err, req, 0)
+	require.NoError(t, retryErr)
 	require.True(t, shouldRetry)
 
 	authProvider := client.AuthorizationProvider.(*DummyAccessTokenProvider)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&authProvider.invalidations))
+}
+
+func TestHTTPRetryAttemptsUseRemainingRequestTimeout(t *testing.T) {
+	client, err := newMockClient()
+	require.NoError(t, err)
+
+	retryHandler, err := NewDefaultRetryHandler(1, time.Millisecond)
+	require.NoError(t, err)
+	client.RetryHandler = retryHandler
+
+	exec := &deadlineRecordingExecutor{
+		firstDelay: 30 * time.Millisecond,
+	}
+	client.executor = exec
+
+	req := &GetRequest{
+		TableName: "T1",
+		Key:       types.NewMapValue(map[string]interface{}{"id": 1}),
+		Timeout:   150 * time.Millisecond,
+	}
+
+	_, err = client.DoExecute(context.Background(), req, []byte{0}, 3, 0)
+	require.Error(t, err)
+	require.Len(t, exec.deadlines, 2)
+
+	skew := exec.deadlines[1].Sub(exec.deadlines[0])
+	if skew < 0 {
+		skew = -skew
+	}
+	if skew >= 20*time.Millisecond {
+		t.Fatalf("retry attempt should keep the original request deadline instead of getting a fresh full timeout, skew=%v", skew)
+	}
+}
+
+func TestRetryDoesNotStartAttemptAfterRequestTimeout(t *testing.T) {
+	client, err := newMockClient()
+	require.NoError(t, err)
+
+	retryHandler, err := NewDefaultRetryHandler(2, 200*time.Millisecond)
+	require.NoError(t, err)
+	client.RetryHandler = retryHandler
+
+	exec := &deadlineRecordingExecutor{
+		firstDelay: 40 * time.Millisecond,
+	}
+	client.executor = exec
+
+	req := &GetRequest{
+		TableName: "T1",
+		Key:       types.NewMapValue(map[string]interface{}{"id": 1}),
+		Timeout:   80 * time.Millisecond,
+	}
+
+	start := time.Now()
+	_, err = client.DoExecute(context.Background(), req, []byte{0}, 3, 0)
+	elapsed := time.Since(start)
+
+	require.Truef(t, nosqlerr.Is(err, nosqlerr.RequestTimeout), "got %v", err)
+	assert.Equal(t, 1, exec.calls, "client should not start another attempt after the total deadline expires")
+	if elapsed >= 250*time.Millisecond {
+		t.Fatalf("expected request timeout near configured deadline, elapsed=%v", elapsed)
+	}
+}
+
+func TestRetrySleepStopsWhenContextCanceled(t *testing.T) {
+	client, err := newMockClient()
+	require.NoError(t, err)
+
+	retryHandler, err := NewDefaultRetryHandler(2, time.Second)
+	require.NoError(t, err)
+	client.RetryHandler = retryHandler
+
+	exec := &deadlineRecordingExecutor{}
+	client.executor = exec
+
+	req := &GetRequest{
+		TableName: "T1",
+		Key:       types.NewMapValue(map[string]interface{}{"id": 1}),
+		Timeout:   5 * time.Second,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err = client.DoExecute(ctx, req, []byte{0}, 3, 0)
+	elapsed := time.Since(start)
+
+	require.Truef(t, errors.Is(err, context.Canceled), "got %v", err)
+	assert.Equal(t, 1, exec.calls)
+	if elapsed >= 300*time.Millisecond {
+		t.Fatalf("expected retry delay to stop on context cancellation, elapsed=%v", elapsed)
+	}
+}
+
+func TestRateLimiterWaitStopsWhenContextCanceled(t *testing.T) {
+	client, err := newMockClient()
+	require.NoError(t, err)
+
+	limiter := common.NewSimpleRateLimiterWithDuration(1, 1)
+	limiter.SetCurrentRate(200)
+
+	req := &GetRequest{
+		TableName: "T1",
+		Key:       types.NewMapValue(map[string]interface{}{"id": 1}),
+		Timeout:   5 * time.Second,
+	}
+	req.SetReadRateLimiter(limiter)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err = client.DoExecute(ctx, req, []byte{0}, 3, 0)
+	elapsed := time.Since(start)
+
+	require.Truef(t, errors.Is(err, context.Canceled), "got %v", err)
+	if elapsed >= 300*time.Millisecond {
+		t.Fatalf("expected rate limiter wait to stop on context cancellation, elapsed=%v", elapsed)
+	}
 }
 
 func newMockClient() (*Client, error) {
@@ -420,4 +552,34 @@ func (e mockErr) Error() string {
 
 func (e mockErr) Temporary() bool {
 	return e.isTemp
+}
+
+type deadlineRecordingExecutor struct {
+	firstDelay time.Duration
+	calls      int
+	deadlines  []time.Time
+}
+
+func (e *deadlineRecordingExecutor) Do(req *http.Request) (*http.Response, error) {
+	e.calls++
+	if deadline, ok := req.Context().Deadline(); ok {
+		e.deadlines = append(e.deadlines, deadline)
+	}
+
+	if e.calls == 1 {
+		if e.firstDelay > 0 {
+			time.Sleep(e.firstDelay)
+		}
+		return nil, &url.Error{
+			Op:  req.Method,
+			URL: req.URL.String(),
+			Err: mockErr{msg: "retryable error", isTemp: true},
+		}
+	}
+
+	return nil, &url.Error{
+		Op:  req.Method,
+		URL: req.URL.String(),
+		Err: mockErr{msg: "non-retryable error"},
+	}
 }

--- a/nosqldb/common/ratelimit.go
+++ b/nosqldb/common/ratelimit.go
@@ -8,6 +8,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -59,37 +60,41 @@ func (rlp *RateLimiterPair) SetWriteRateLimiter(rl RateLimiter) {
 // RateLimiter interface provides default methods that all rate limiters
 // must implement.
 //
-// Thread safety
+// # Thread safety
 //
 // It is expected that all implementing classes of this
 // interface may be used by multiple goroutines concurrently. For example, many
 // goroutines may be using the same rate limiter instance to ensure that
 // all of them together do not exceed a given limit.
 //
-// Typical usage
+// # Typical usage
 //
 // The simplest use of the rate limiter is to consume a number of units,
 // blocking until they are successfully consumed:
+//
 //	delay := rateLimiter.ConsumeUnits(units)
 //	// delay indicates how long the consume delayed
 //
 // To poll a limiter to see if it is currently over the limit:
+//
 //	if rateLimiter.TryConsumeUnits(0) {
 //	  // limiter is below its limit
 //	}
 //
 // To attempt to consume units, only if they can be immediately consumed
 // without waiting:
+//
 //	if ratelimiter.TryConsumeUnits(units) {
 //	  // successful consume
 //	} else {
 //	  // could not consume units without waiting
 //	}
 //
-// Usages with timeouts
+// # Usages with timeouts
 //
 // In cases where the number of units an operation will consume is already
 // known before the operation, a simple one-shot method can be used:
+//
 //	var units int64 = (known units the operation will use)
 //	alwaysConsume := false // don't consume if we time out
 //	delay, err := rateLimiter.ConsumeUnitsWithTimeout(units, timeout, alwaysConsume)
@@ -105,6 +110,7 @@ func (rlp *RateLimiterPair) SetWriteRateLimiter(rl RateLimiter) {
 // known before the operation, typically two rate limiter calls would be
 // used: one to wait till the limiter is below its limit, and a second
 // to update the limiter with used units:
+//
 //	// wait until we're under the limit
 //	delay, err := rateLimiter.ConsumeUnitsWithTimeout(0, timeout, false)
 //	if err != nil {
@@ -119,6 +125,7 @@ func (rlp *RateLimiterPair) SetWriteRateLimiter(rl RateLimiter) {
 //
 // Alternately, the operation could be always performed, and then the
 // limiter could try to wait for the units to be consumed:
+//
 //	var units int64  = (...do operation, get number of units used...)
 //	alwaysConsume := true // consume, even if we time out
 //	delay, err := rateLimiter.ConsumeUnitsWithTimeout(units, timeout, alwaysConsume)
@@ -132,7 +139,7 @@ func (rlp *RateLimiterPair) SetWriteRateLimiter(rl RateLimiter) {
 //	  // consume was successful
 //	}
 //
-// Limiter duration
+// # Limiter duration
 //
 // Implementing rate limiters should support a configurable "duration".
 // This is sometimes referred to as a "burst mode", or a "window time",
@@ -216,6 +223,16 @@ type RateLimiter interface {
 	// the rate limit.
 	// rateToSet may be greater than 100.0 to set the limiter to "over its limit".
 	SetCurrentRate(rateToSet float64)
+}
+
+// ContextRateLimiter can be implemented by RateLimiter implementations that
+// can stop waiting when the request context is canceled.
+type ContextRateLimiter interface {
+	RateLimiter
+
+	// ConsumeUnitsWithContext attempts to consume a number of units, blocking
+	// until the units are available, the timeout expires, or ctx is canceled.
+	ConsumeUnitsWithContext(ctx context.Context, units int64, timeout time.Duration, alwaysConsume bool) (time.Duration, error)
 }
 
 const nanosPerSecFloat = 1000000000.0
@@ -349,6 +366,12 @@ func (srl *SimpleRateLimiter) ConsumeUnits(units int64) time.Duration {
 // currently over its limit, use TryConsumeUnits() instead.
 // If alwaysConsume is true, consume units even on timeout.
 func (srl *SimpleRateLimiter) ConsumeUnitsWithTimeout(units int64, timeout time.Duration, alwaysConsume bool) (time.Duration, error) {
+	return srl.ConsumeUnitsWithContext(context.Background(), units, timeout, alwaysConsume)
+}
+
+// ConsumeUnitsWithContext attempts to consume a number of units, blocking until
+// the units are available, the specified timeout expires, or ctx is canceled.
+func (srl *SimpleRateLimiter) ConsumeUnitsWithContext(ctx context.Context, units int64, timeout time.Duration, alwaysConsume bool) (time.Duration, error) {
 
 	// call internal logic, get the time we need to sleep to
 	// complete the consume.
@@ -362,15 +385,37 @@ func (srl *SimpleRateLimiter) ConsumeUnitsWithTimeout(units int64, timeout time.
 	// Note the units may have already been consumed if alwaysConsume
 	// is true.
 	if timeout > 0 && sleepTime >= timeout {
-		time.Sleep(timeout)
+		if waited, err := sleepWithContext(ctx, timeout); err != nil {
+			return waited, err
+		}
 		return timeout, fmt.Errorf("timed out waiting %dms for %d units in rate limiter", (timeout / time.Millisecond), units)
 	}
 
 	// sleep for the requested time.
-	time.Sleep(sleepTime)
+	waited, err := sleepWithContext(ctx, sleepTime)
+	if err != nil {
+		return waited, err
+	}
 
 	// return the amount of time slept
 	return sleepTime, nil
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) (time.Duration, error) {
+	if d <= 0 {
+		return 0, nil
+	}
+
+	start := time.Now()
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return d, nil
+	case <-ctx.Done():
+		return time.Since(start), ctx.Err()
+	}
 }
 
 // consumeInternal returns the time to sleep to consume units.
@@ -380,7 +425,6 @@ func (srl *SimpleRateLimiter) ConsumeUnitsWithTimeout(units int64, timeout time.
 //
 // This is the only method that actually "consumes units", i.e.
 // updates the lastNano value.
-//
 func (srl *SimpleRateLimiter) consumeInternal(units int64, timeout time.Duration,
 	alwaysConsume bool, nowNanos int64) time.Duration {
 

--- a/nosqldb/common/ratelimit_test.go
+++ b/nosqldb/common/ratelimit_test.go
@@ -8,6 +8,8 @@
 package common
 
 import (
+	"context"
+	"errors"
 	"math/rand"
 	"testing"
 	"time"
@@ -65,6 +67,29 @@ func TestDurationLogic(t *testing.T) {
 	delay = limiter.ConsumeUnits(10)
 	if delay > 0 {
 		t.Fatalf("Expected limiter delay of 0ms, got %dus", (delay / time.Microsecond))
+	}
+}
+
+func TestConsumeUnitsWithContextCancellation(t *testing.T) {
+	limiter := NewSimpleRateLimiterWithDuration(1, 1)
+	limiter.SetCurrentRate(200)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := limiter.ConsumeUnitsWithContext(ctx, 0, 2*time.Second, false)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if elapsed >= 300*time.Millisecond {
+		t.Fatalf("expected limiter wait to stop early, elapsed=%v", elapsed)
 	}
 }
 

--- a/nosqldb/retry.go
+++ b/nosqldb/retry.go
@@ -8,6 +8,7 @@
 package nosqldb
 
 import (
+	"context"
 	"errors"
 	"math/rand"
 	"time"
@@ -52,6 +53,17 @@ type RetryHandler interface {
 	Delay(req Request, numRetries uint, err error)
 }
 
+// ContextRetryHandler can be implemented by RetryHandler implementations that
+// can stop delaying when the request context is canceled.
+type ContextRetryHandler interface {
+	RetryHandler
+
+	// DelayWithContext is called when a retryable error is reported and the
+	// request will be retried. It should wait for the desired retry delay or
+	// return early if ctx is canceled.
+	DelayWithContext(ctx context.Context, req Request, numRetries uint, err error) error
+}
+
 const securityErrorRetryInterval = 100 * time.Millisecond
 
 // DefaultRetryHandler represents the default implementation of RetryHandler interface.
@@ -93,6 +105,12 @@ func (r DefaultRetryHandler) MaxNumRetries() uint {
 // less than or equal to 10. Otherwise, it uses the exponential backoff algorithm
 // to compute the time of delay.
 func (r DefaultRetryHandler) Delay(req Request, numRetries uint, err error) {
+	_ = r.DelayWithContext(context.Background(), req, numRetries, err)
+}
+
+// DelayWithContext causes the current goroutine to pause for a period of time,
+// or returns early if the context is canceled.
+func (r DefaultRetryHandler) DelayWithContext(ctx context.Context, req Request, numRetries uint, err error) error {
 	d := r.retryInterval
 	if nosqlerr.IsSecurityInfoUnavailable(err) {
 		d = securityInfoNotReadyDelay(numRetries, req)
@@ -104,12 +122,26 @@ func (r DefaultRetryHandler) Delay(req Request, numRetries uint, err error) {
 		if (d + req.GetRetryTime()) > req.timeout() {
 			d = req.timeout() - req.GetRetryTime()
 			if d < 0 {
-				return
+				return nil
 			}
 		}
 	}
+
+	if d <= 0 {
+		return ctx.Err()
+	}
+
 	req.SetRetryTime(req.GetRetryTime() + d)
-	time.Sleep(d)
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // ShouldRetry reports whether the request should continue to retry upon


### PR DESCRIPTION
## Summary
Enforces end-to-end request timeout behavior across HTTP retry attempts, retry sleeps, and rate-limiter waits.

## Changes
- Use remaining request timeout for each HTTP retry attempt.
- Avoid starting a new HTTP attempt after the total request deadline has expired.
- Make retry sleep context-aware.
- Make rate-limiter waits context-aware.
- Preserve RetryAuthentication token invalidation behavior from the merged auth lifecycle PR.
- Add regression tests for retry deadlines, timeout expiry, retry cancellation, and rate-limiter cancellation.

## Validation
- go test -count=1 ./nosqldb -run 'TestHTTPRetryAttemptsUseRemainingRequestTimeout|TestRetryDoesNotStartAttemptAfterRequestTimeout|TestRetrySleepStopsWhenContextCanceled|TestRateLimiterWaitStopsWhenContextCanceled|TestHandleErrorInvalidatesCachedAuthTokenOnRetryAuthentication'
- go test -count=1 ./nosqldb
- go test -count=1 ./nosqldb/common -run 'TestConsumeUnitsWithContextCancellation|TestDurationLogic|TestLoggingLimiter|TestSubUnitLimits|TestWithoutTimeouts|TestWithTimeouts'
- git diff --check