### PR TITLE
Synchronize client shared limiter and topology state

### DIFF
--- a/nosqldb/client.go
+++ b/nosqldb/client.go
@@ -79,7 +79,7 @@ type Client struct {
 
 	// Keep an internal map of tablename to next limits update time
 	tableLimitUpdateMap map[string]int64
-	limitMux            sync.Mutex
+	limitMux            sync.RWMutex
 
 	// (possibly negotiated) version of the protocol in use
 	serialVersion int16
@@ -88,7 +88,8 @@ type Client struct {
 	queryVersion int16
 
 	// latest topology from any request/response opearation
-	topology *common.TopologyInfo
+	topology    *common.TopologyInfo
+	topologyMux sync.RWMutex
 
 	// for managing one-time messaging
 	oneTimeMessages map[string]struct{}
@@ -965,7 +966,7 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 
 	if queryReq, ok := req.(*QueryRequest); ok && !queryReq.isInternalRequest() {
 
-		req.SetTopology(c.topology)
+		req.SetTopology(c.getTopologyInfo())
 
 		// If the QueryRequest represents an advanced query, it will be bound
 		// with a queryDriver the first time the execute() is called for the query.
@@ -1039,15 +1040,15 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 	}
 
 	// if not, see if we have limiters in our map for the given table
-	if c.rateLimiterMap != nil && readLimiter == nil && writeLimiter == nil {
+	if readLimiter == nil && writeLimiter == nil {
 		tableName := req.getTableName()
 		if tableName != "" {
-			rp, ok := c.rateLimiterMap[strings.ToLower(tableName)]
-			if !ok {
+			rp, ok, enabled := c.getRateLimiterPair(tableName)
+			if enabled && !ok {
 				if req.doesReads() || req.doesWrites() {
 					c.backgroundUpdateLimiters(tableName)
 				}
-			} else {
+			} else if ok {
 				writeLimiter = rp.WriteLimiter
 				readLimiter = rp.ReadLimiter
 				req.SetReadRateLimiter(readLimiter)
@@ -1215,7 +1216,7 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 
 		// set the topology in the request, if not set already
 		if queryReq, ok := req.(*QueryRequest); !ok || queryReq.isInternalRequest() {
-			req.SetTopology(c.topology)
+			req.SetTopology(c.getTopologyInfo())
 		}
 
 		// Handle errors that may occur when retrieving authorization string.
@@ -1314,7 +1315,7 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 
 		c.setTopologyInfo(result.GetTopologyInfo())
 
-		if tResult, ok := result.(*TableResult); ok && c.rateLimiterMap != nil {
+		if tResult, ok := result.(*TableResult); ok && c.rateLimitingEnabled() {
 			// update rate limiter settings for table
 			c.updateRateLimiters(tResult.TableName, tResult.Limits)
 		}
@@ -1341,8 +1342,23 @@ func (c *Client) setTopologyInfo(ti *common.TopologyInfo) {
 	if ti == nil {
 		return
 	}
+
+	c.topologyMux.Lock()
+	defer c.topologyMux.Unlock()
+
 	if c.topology == nil || c.topology.SeqNum < ti.SeqNum {
-		c.topology = ti
+		c.topology = cloneTopologyInfo(ti)
+	}
+}
+
+func cloneTopologyInfo(ti *common.TopologyInfo) *common.TopologyInfo {
+	if ti == nil {
+		return nil
+	}
+
+	return &common.TopologyInfo{
+		SeqNum:   ti.SeqNum,
+		ShardIDs: append([]int(nil), ti.ShardIDs...),
 	}
 }
 
@@ -1365,7 +1381,7 @@ func (c *Client) warmupClientAuth() {
 	c.logger.Fine("Auth warmed up successfully")
 }
 
-func (c *Client) tableNeedsRefresh(tableName string) bool {
+func (c *Client) tableNeedsRefreshLocked(tableName string) bool {
 	if c.tableLimitUpdateMap == nil {
 		return false
 	}
@@ -1375,7 +1391,7 @@ func (c *Client) tableNeedsRefresh(tableName string) bool {
 	return then <= nowNanos
 }
 
-func (c *Client) setTableNeedsRefresh(tableName string, needsRefresh bool) {
+func (c *Client) setTableNeedsRefreshLocked(tableName string, needsRefresh bool) {
 	if c.tableLimitUpdateMap == nil {
 		return
 	}
@@ -1394,14 +1410,41 @@ func (c *Client) backgroundUpdateLimiters(tableName string) {
 
 	c.limitMux.Lock()
 
-	if !c.tableNeedsRefresh(lTable) {
+	if !c.tableNeedsRefreshLocked(lTable) {
 		c.limitMux.Unlock()
 		return
 	}
-	c.setTableNeedsRefresh(lTable, false)
+	c.setTableNeedsRefreshLocked(lTable, false)
 	c.limitMux.Unlock()
 
 	go c.updateTableLimiters(lTable)
+}
+
+func (c *Client) rateLimitingEnabled() bool {
+	c.limitMux.RLock()
+	defer c.limitMux.RUnlock()
+	return c.rateLimiterMap != nil
+}
+
+func (c *Client) getRateLimiterPair(tableName string) (common.RateLimiterPair, bool, bool) {
+	c.limitMux.RLock()
+	defer c.limitMux.RUnlock()
+
+	if c.rateLimiterMap == nil {
+		return common.RateLimiterPair{}, false, false
+	}
+
+	rp, ok := c.rateLimiterMap[strings.ToLower(tableName)]
+	return rp, ok, true
+}
+
+func (c *Client) setTableLimitRefreshTime(tableName string, refreshTimeNanos int64) {
+	c.limitMux.Lock()
+	defer c.limitMux.Unlock()
+
+	if c.tableLimitUpdateMap != nil {
+		c.tableLimitUpdateMap[strings.ToLower(tableName)] = refreshTimeNanos
+	}
 }
 
 // Comsume rate limiter units after successful operation.
@@ -1432,13 +1475,16 @@ func (c *Client) consumeLimiterUnitsWithContext(ctx context.Context, rl common.R
 }
 
 func (c *Client) updateRateLimiters(tableName string, limits TableLimits) bool {
+	lTable := strings.ToLower(tableName)
+
+	c.limitMux.Lock()
+	defer c.limitMux.Unlock()
+
 	if c.rateLimiterMap == nil {
 		return false
 	}
 
-	lTable := strings.ToLower(tableName)
-
-	c.setTableNeedsRefresh(lTable, false)
+	c.setTableNeedsRefreshLocked(lTable, false)
 
 	if limits.ReadUnits <= 0 && limits.WriteUnits <= 0 {
 		delete(c.rateLimiterMap, lTable)
@@ -1486,13 +1532,13 @@ func (c *Client) updateTableLimiters(tableName string) {
 	if err != nil {
 		c.logger.Info("GetTableRequest for table '%s' returned error: %v", tableName, err)
 		// allow retry after 100ms
-		c.tableLimitUpdateMap[tableName] = time.Now().UnixNano() + (100 * 1000 * 1000)
+		c.setTableLimitRefreshTime(tableName, time.Now().UnixNano()+(100*1000*1000))
 		return
 	}
 	if res == nil {
 		c.logger.Info("GetTableRequest for table '%s' returned nil", tableName)
 		// allow retry after 100ms
-		c.tableLimitUpdateMap[tableName] = time.Now().UnixNano() + (100 * 1000 * 1000)
+		c.setTableLimitRefreshTime(tableName, time.Now().UnixNano()+(100*1000*1000))
 		return
 	}
 
@@ -1880,6 +1926,9 @@ func isRetryableError(err error) bool {
 // EnableRateLimiting is for testing purposes only. Applications should set
 // RateLimitingEnabled to true in the client Config to enable rate limiting.
 func (c *Client) EnableRateLimiting(enable bool, usePercent float64) {
+	c.limitMux.Lock()
+	defer c.limitMux.Unlock()
+
 	c.RateLimiterPercentage = usePercent
 	if enable {
 		if c.rateLimiterMap != nil {
@@ -1895,13 +1944,18 @@ func (c *Client) EnableRateLimiting(enable bool, usePercent float64) {
 
 // ResetRateLimiters is for testing puposes only.
 func (c *Client) ResetRateLimiters(tableName string) {
+	c.limitMux.RLock()
 	if c.rateLimiterMap == nil {
+		c.limitMux.RUnlock()
 		return
 	}
 	rp, ok := c.rateLimiterMap[strings.ToLower(tableName)]
 	if !ok {
+		c.limitMux.RUnlock()
 		return
 	}
+	c.limitMux.RUnlock()
+
 	rp.WriteLimiter.Reset()
 	rp.ReadLimiter.Reset()
 }
@@ -1976,7 +2030,9 @@ func (c *Client) decrementQueryVersion(queryVerUsed int16) bool {
 
 // getTopologyInfo returns the topology info stored in the client
 func (c *Client) getTopologyInfo() *common.TopologyInfo {
-	return c.topology
+	c.topologyMux.RLock()
+	defer c.topologyMux.RUnlock()
+	return cloneTopologyInfo(c.topology)
 }
 
 // GetQueryVersion is used for tests.

--- a/nosqldb/client_test.go
+++ b/nosqldb/client_test.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -442,6 +443,88 @@ func TestRateLimiterWaitStopsWhenContextCanceled(t *testing.T) {
 	if elapsed >= 300*time.Millisecond {
 		t.Fatalf("expected rate limiter wait to stop on context cancellation, elapsed=%v", elapsed)
 	}
+}
+
+func TestConcurrentLimiterMapAndTopologyAccess(t *testing.T) {
+	client, err := newMockClient()
+	require.NoError(t, err)
+	client.EnableRateLimiting(true, 100)
+
+	const tableName = "T1"
+	client.updateRateLimiters(tableName, TableLimits{ReadUnits: 100, WriteUnits: 100})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				rp, ok, enabled := client.getRateLimiterPair(tableName)
+				if enabled && ok {
+					rp.ReadLimiter.TryConsumeUnits(1)
+					rp.WriteLimiter.TryConsumeUnits(1)
+					_ = rp.ReadLimiter.GetCurrentRate()
+					_ = rp.WriteLimiter.GetCurrentRate()
+				}
+				client.ResetRateLimiters(tableName)
+			}
+		}()
+	}
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(offset uint) {
+			defer wg.Done()
+			for j := uint(0); j < 1000; j++ {
+				if j%20 == 0 {
+					client.updateRateLimiters(tableName, TableLimits{})
+				} else {
+					client.updateRateLimiters(tableName, TableLimits{
+						ReadUnits:  50 + offset + j%10,
+						WriteUnits: 50 + offset + j%10,
+					})
+				}
+				client.setTableLimitRefreshTime(tableName, time.Now().UnixNano())
+			}
+		}(uint(i))
+	}
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(offset int) {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				client.setTopologyInfo(&common.TopologyInfo{
+					SeqNum:   offset*1000 + j,
+					ShardIDs: []int{j, j + 1, j + 2},
+				})
+				ti := client.getTopologyInfo()
+				if ti != nil && len(ti.ShardIDs) > 0 {
+					ti.ShardIDs[0] = -1
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestTopologyInfoIsCloned(t *testing.T) {
+	client, err := newMockClient()
+	require.NoError(t, err)
+
+	client.setTopologyInfo(&common.TopologyInfo{
+		SeqNum:   1,
+		ShardIDs: []int{1, 2, 3},
+	})
+
+	ti := client.getTopologyInfo()
+	require.NotNil(t, ti)
+	ti.ShardIDs[0] = 99
+
+	ti = client.getTopologyInfo()
+	require.NotNil(t, ti)
+	require.Equal(t, []int{1, 2, 3}, ti.ShardIDs)
 }
 
 func newMockClient() (*Client, error) {

--- a/nosqldb/common/ratelimit.go
+++ b/nosqldb/common/ratelimit.go
@@ -277,17 +277,20 @@ func NewSimpleRateLimiterWithDuration(rateLimitPerSec float64, durationSecs floa
 // Changing the limit may lead to unexpected spiky behavior, and may
 // affect other goroutines currently operating on the same limiter instance.
 func (srl *SimpleRateLimiter) SetLimitPerSecond(rateLimitPerSec float64) {
+	srl.mux.Lock()
+	defer srl.mux.Unlock()
+
 	if rateLimitPerSec <= 0.0 {
 		srl.nanosPerUnit = 0
 	} else {
 		srl.nanosPerUnit = (int64)(nanosPerSecFloat / rateLimitPerSec)
 	}
-	srl.enforceMinimumDuration()
+	srl.enforceMinimumDurationLocked()
 }
 
 // Ensure that any duration set will allow a consume of 1 unit to
 // succeed
-func (srl *SimpleRateLimiter) enforceMinimumDuration() {
+func (srl *SimpleRateLimiter) enforceMinimumDurationLocked() {
 	if srl.durationNanos < srl.nanosPerUnit {
 		srl.durationNanos = srl.nanosPerUnit
 	}
@@ -296,11 +299,19 @@ func (srl *SimpleRateLimiter) enforceMinimumDuration() {
 // GetLimitPerSecond returns the number of units configured for this rate limiter instance
 // (the max number of units per second this limiter allows).
 func (srl *SimpleRateLimiter) GetLimitPerSecond() float64 {
+	srl.mux.Lock()
+	defer srl.mux.Unlock()
+	return srl.getLimitPerSecondLocked()
+}
+
+func (srl *SimpleRateLimiter) getLimitPerSecondLocked() float64 {
 	return nanosPerSecFloat / (float64)(srl.nanosPerUnit)
 }
 
 // GetDuration returns the duration in seconds configured for this rate limiter instance
 func (srl *SimpleRateLimiter) GetDuration() float64 {
+	srl.mux.Lock()
+	defer srl.mux.Unlock()
 	return (float64)(srl.durationNanos) / nanosPerSecFloat
 }
 
@@ -313,12 +324,17 @@ func (srl *SimpleRateLimiter) GetDuration() float64 {
 // 5 seconds, a call to TryConsumeUnits(5000) will succeed
 // immediately with no waiting.
 func (srl *SimpleRateLimiter) SetDuration(durationSecs float64) {
+	srl.mux.Lock()
+	defer srl.mux.Unlock()
+
 	srl.durationNanos = (int64)(durationSecs * nanosPerSecFloat)
-	srl.enforceMinimumDuration()
+	srl.enforceMinimumDurationLocked()
 }
 
 // Reset resets the rate limiter as if it was newly constructed.
 func (srl *SimpleRateLimiter) Reset() {
+	srl.mux.Lock()
+	defer srl.mux.Unlock()
 	srl.lastNano = time.Now().UnixNano()
 }
 
@@ -327,6 +343,9 @@ func (srl *SimpleRateLimiter) Reset() {
 // the rate limit.
 // rateToSet may be greater than 100.0 to set the limiter to "over its limit".
 func (srl *SimpleRateLimiter) SetCurrentRate(percent float64) {
+	srl.mux.Lock()
+	defer srl.mux.Unlock()
+
 	// Note that "rate" isn't really clearly defined in this type
 	// of limiter, because there is no inherent "time period". So
 	// all "rate" operations just assume "for 1 second".
@@ -428,14 +447,14 @@ func sleepWithContext(ctx context.Context, d time.Duration) (time.Duration, erro
 func (srl *SimpleRateLimiter) consumeInternal(units int64, timeout time.Duration,
 	alwaysConsume bool, nowNanos int64) time.Duration {
 
+	// lock so only one goroutine at a time can update
+	srl.mux.Lock()
+	defer srl.mux.Unlock()
+
 	// If disabled, just return success
 	if srl.nanosPerUnit <= 0 {
 		return 0
 	}
-
-	// lock so only one goroutine at a time can update
-	srl.mux.Lock()
-	defer srl.mux.Unlock()
 
 	// determine how many nanos we need to add based on units requested
 	nanosNeeded := units * srl.nanosPerUnit
@@ -501,9 +520,12 @@ func (srl *SimpleRateLimiter) TryConsumeUnits(units int64) bool {
 
 // GetCurrentRate returns the current rate as a percentage of current limit (0.0 - 100.0).
 func (srl *SimpleRateLimiter) GetCurrentRate() float64 {
+	srl.mux.Lock()
+	defer srl.mux.Unlock()
+
 	// see comment in setCurrentRate()
-	capacity := srl.getCapacity()
-	limit := srl.GetLimitPerSecond()
+	capacity := srl.getCapacityLocked()
+	limit := srl.getLimitPerSecondLocked()
 	rate := 100.0 - ((capacity * 100.0) / limit)
 	if rate < 0.0 {
 		return 0.0
@@ -520,7 +542,7 @@ func (srl *SimpleRateLimiter) ConsumeUnitsUnconditionally(units int64) {
 	srl.consumeInternal(units, 0, true, time.Now().UnixNano())
 }
 
-func (srl *SimpleRateLimiter) getCapacity() float64 {
+func (srl *SimpleRateLimiter) getCapacityLocked() float64 {
 	// ensure we never use more from the past than duration allows
 	nowNanos := time.Now().UnixNano()
 	maxPast := nowNanos - srl.durationNanos
@@ -531,6 +553,16 @@ func (srl *SimpleRateLimiter) getCapacity() float64 {
 }
 
 func (srl *SimpleRateLimiter) String() string {
+	srl.mux.Lock()
+	defer srl.mux.Unlock()
+
+	capacity := srl.getCapacityLocked()
+	limit := srl.getLimitPerSecondLocked()
+	rate := 100.0 - ((capacity * 100.0) / limit)
+	if rate < 0.0 {
+		rate = 0.0
+	}
+
 	return fmt.Sprintf("lastNano=%v, nanosPerUnit=%v, durationNanos=%v, limit=%v, capacity=%v, rate=%.2f",
-		srl.lastNano, srl.nanosPerUnit, srl.durationNanos, srl.GetLimitPerSecond(), srl.getCapacity(), srl.GetCurrentRate())
+		srl.lastNano, srl.nanosPerUnit, srl.durationNanos, limit, capacity, rate)
 }


### PR DESCRIPTION
## Summary
Synchronizes shared Client rate-limiter maps and topology state used by concurrent request goroutines.

## Changes
- Add locking around client rate limiter map access.
- Add locking around table limit refresh map access.
- Add synchronized topology get/set helpers.
- Clone topology data on read/write to avoid callers mutating shared client state.
- Add concurrent stress coverage for limiter map/topology access.

## Validation
- go test -count=1 ./nosqldb -run 'TestConcurrentLimiterMapAndTopologyAccess|TestTopologyInfoIsCloned|TestHTTPRetryAttemptsUseRemainingRequestTimeout|TestHandleErrorInvalidatesCachedAuthTokenOnRetryAuthentication'
- go test -count=1 -race ./nosqldb -run 'TestConcurrentLimiterMapAndTopologyAccess|TestTopologyInfoIsCloned'
- go test -count=1 ./nosqldb
- git diff --check