### PR TITLE
Preserve query intent across continuations and downgrades

### DIFF
--- a/nosqldb/nson_serializer.go
+++ b/nosqldb/nson_serializer.go
@@ -1456,6 +1456,10 @@ func (req *PrepareRequest) deserialize(r proto.Reader, serialVersion int16, quer
 }
 
 func (req *QueryRequest) serialize(w proto.Writer, serialVersion int16, queryVersion int16) (err error) {
+	if err = req.checkQueryVersionSupported(queryVersion); err != nil {
+		return
+	}
+
 	ns := startRequest(w)
 
 	// header

--- a/nosqldb/request.go
+++ b/nosqldb/request.go
@@ -21,6 +21,7 @@ import (
 	"github.com/oracle/nosql-go-sdk/nosqldb/nosqlerr"
 	"github.com/oracle/nosql-go-sdk/nosqldb/types"
 )
+
 // HasLastWriteMetadata is implemented by requests that can carry last write
 // metadata and report whether the request currently includes the metadata.
 type HasLastWriteMetadata interface {
@@ -1908,21 +1909,53 @@ func (r *QueryRequest) getVirtualScan() *virtualScan {
 // copyInternal creates an internal QueryRequest out of the application provided QueryRequest.
 func (r *QueryRequest) copyInternal() *QueryRequest {
 	return &QueryRequest{
-		Timeout:              r.Timeout,
-		Limit:                r.Limit,
-		MaxReadKB:            r.MaxReadKB,
-		MaxWriteKB:           r.MaxWriteKB,
-		MaxMemoryConsumption: r.MaxMemoryConsumption,
-		Consistency:          r.Consistency,
-		Durability:           r.Durability,
-		PreparedStatement:    r.PreparedStatement,
-		driver:               r.driver,
-		traceLevel:           r.traceLevel,
-		TableName:            r.TableName,
-		InternalRequestData:  r.InternalRequestData,
-		LastWriteMetadata:    r.LastWriteMetadata,
-		isInternal:           true,
+		Timeout:                    r.Timeout,
+		Limit:                      r.Limit,
+		MaxReadKB:                  r.MaxReadKB,
+		MaxWriteKB:                 r.MaxWriteKB,
+		MaxMemoryConsumption:       r.MaxMemoryConsumption,
+		MaxServerMemoryConsumption: r.MaxServerMemoryConsumption,
+		FPArithSpec:                r.FPArithSpec,
+		Consistency:                r.Consistency,
+		Durability:                 r.Durability,
+		PreparedStatement:          r.PreparedStatement,
+		driver:                     r.driver,
+		traceLevel:                 r.traceLevel,
+		TableName:                  r.TableName,
+		Namespace:                  r.Namespace,
+		InternalRequestData:        r.InternalRequestData,
+		LastWriteMetadata:          r.LastWriteMetadata,
+		StructType:                 r.StructType,
+		isInternal:                 true,
 	}
+}
+
+func (r *QueryRequest) checkQueryVersionSupported(queryVersion int16) error {
+	if queryVersion < 4 && r.virtualScan != nil {
+		return nosqlerr.NewIllegalArgument("query virtual scan state requires query version 4 or later")
+	}
+	return nil
+}
+
+func (r *QueryRequest) checkSerialVersionSupported(serialVersion int16) error {
+	if serialVersion >= 4 {
+		return nil
+	}
+
+	switch {
+	case r.Namespace != "":
+		return nosqlerr.NewIllegalArgument("query namespace requires protocol version 4 or later")
+	case r.MaxServerMemoryConsumption != 0:
+		return nosqlerr.NewIllegalArgument("query server memory limit requires protocol version 4 or later")
+	case r.LastWriteMetadata != "":
+		return nosqlerr.NewIllegalArgument("query last write metadata requires protocol version 4 or later")
+	case r.virtualScan != nil:
+		return nosqlerr.NewIllegalArgument("query virtual scan state requires protocol version 4 or later")
+	case r.Durability.IsSet():
+		return nosqlerr.NewIllegalArgument("query durability requires protocol version 4 or later")
+	}
+
+	return nil
 }
 
 // hasDriver reports whether the QueryRequest is bound with a query driver.

--- a/nosqldb/request_test.go
+++ b/nosqldb/request_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/oracle/nosql-go-sdk/nosqldb/internal/proto"
+	"github.com/oracle/nosql-go-sdk/nosqldb/internal/proto/binary"
 	"github.com/oracle/nosql-go-sdk/nosqldb/nosqlerr"
 	"github.com/oracle/nosql-go-sdk/nosqldb/types"
 	"github.com/stretchr/testify/suite"
@@ -38,6 +40,129 @@ type RequestTestSuite struct {
 
 func TestOpRequests(t *testing.T) {
 	suite.Run(t, new(RequestTestSuite))
+}
+
+func TestQueryRequestCopyInternalPreservesQueryIntent(t *testing.T) {
+	fpSpec := Decimal64
+	structType := reflect.TypeOf(struct {
+		ID int
+	}{})
+	req := &QueryRequest{
+		Timeout:                    3 * time.Second,
+		Limit:                      17,
+		MaxReadKB:                  11,
+		MaxWriteKB:                 12,
+		MaxMemoryConsumption:       13,
+		MaxServerMemoryConsumption: 14,
+		FPArithSpec:                &fpSpec,
+		Consistency:                types.Absolute,
+		Durability: types.Durability{
+			MasterSync:  types.SyncPolicySync,
+			ReplicaSync: types.SyncPolicyNoSync,
+			ReplicaAck:  types.ReplicaAckPolicySimpleMajority,
+		},
+		PreparedStatement: &PreparedStatement{},
+		traceLevel:        4,
+		TableName:         "T1",
+		Namespace:         "ns1",
+		LastWriteMetadata: "created-by:tester",
+		StructType:        structType,
+	}
+
+	internal := req.copyInternal()
+
+	if !internal.isInternal {
+		t.Fatal("copyInternal() did not mark the copied request as internal")
+	}
+	if internal.Namespace != req.Namespace {
+		t.Fatalf("copyInternal() Namespace=%q, want %q", internal.Namespace, req.Namespace)
+	}
+	if internal.MaxServerMemoryConsumption != req.MaxServerMemoryConsumption {
+		t.Fatalf("copyInternal() MaxServerMemoryConsumption=%d, want %d",
+			internal.MaxServerMemoryConsumption, req.MaxServerMemoryConsumption)
+	}
+	if internal.FPArithSpec != req.FPArithSpec {
+		t.Fatal("copyInternal() did not preserve FPArithSpec")
+	}
+	if internal.StructType != req.StructType {
+		t.Fatal("copyInternal() did not preserve StructType")
+	}
+}
+
+func TestQueryRequestRejectsVirtualScanQueryVersionDowngrade(t *testing.T) {
+	req := &QueryRequest{
+		Statement:   "select * from T1",
+		virtualScan: &virtualScan{shardID: 1, partitionID: 2},
+	}
+
+	err := req.serialize(binary.NewWriter(), 4, proto.QueryV3)
+	if err == nil {
+		t.Fatal("expected virtual scan query version downgrade to fail")
+	}
+	if !nosqlerr.Is(err, nosqlerr.IllegalArgument) {
+		t.Fatalf("got error %v, want IllegalArgument", err)
+	}
+}
+
+func TestQueryRequestRejectsSerialV3UnsupportedIntent(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *QueryRequest
+	}{
+		{
+			name: "namespace",
+			req:  &QueryRequest{Statement: "select * from T1", Namespace: "ns1"},
+		},
+		{
+			name: "server memory",
+			req:  &QueryRequest{Statement: "select * from T1", MaxServerMemoryConsumption: 1},
+		},
+		{
+			name: "last write metadata",
+			req:  &QueryRequest{Statement: "delete from T1 where id = 1", LastWriteMetadata: "deleted-by:tester"},
+		},
+		{
+			name: "virtual scan",
+			req:  &QueryRequest{Statement: "select * from T1", virtualScan: &virtualScan{shardID: 1}},
+		},
+		{
+			name: "durability",
+			req: &QueryRequest{
+				Statement: "delete from T1 where id = 1",
+				Durability: types.Durability{
+					MasterSync:  types.SyncPolicySync,
+					ReplicaSync: types.SyncPolicyNoSync,
+					ReplicaAck:  types.ReplicaAckPolicySimpleMajority,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.req.serializeV3(binary.NewWriter(), 3)
+			if err == nil {
+				t.Fatal("expected serial V3 serialization to reject unsupported query intent")
+			}
+			if !nosqlerr.Is(err, nosqlerr.IllegalArgument) {
+				t.Fatalf("got error %v, want IllegalArgument", err)
+			}
+		})
+	}
+}
+
+func TestQueryRequestSerialV3AllowsRepresentableIntent(t *testing.T) {
+	req := &QueryRequest{
+		Statement:   "select * from T1",
+		Limit:       10,
+		MaxReadKB:   20,
+		MaxWriteKB:  30,
+		Consistency: types.Eventual,
+	}
+
+	if err := req.serializeV3(binary.NewWriter(), 3); err != nil {
+		t.Fatalf("serializeV3() got unexpected error: %v", err)
+	}
 }
 
 func (suite *RequestTestSuite) TestValidateTimeout() {

--- a/nosqldb/v3_serializer.go
+++ b/nosqldb/v3_serializer.go
@@ -976,6 +976,10 @@ func deserializeV3TopologyInfo(r proto.Reader) (topoInfo *common.TopologyInfo, e
 }
 
 func (req *QueryRequest) serializeV3(w proto.Writer, serialVersion int16) (err error) {
+	if err = req.checkSerialVersionSupported(serialVersion); err != nil {
+		return
+	}
+
 	if err = serializeV3Op(w, proto.Query, req.Timeout); err != nil {
 		return
 	}


### PR DESCRIPTION
## Summary
Preserves query intent for internal query continuations and rejects unsupported intent when downgrading to older protocol paths.

## Changes
- Preserve QueryRequest Namespace in internal continuation copies.
- Preserve MaxServerMemoryConsumption in internal continuation copies.
- Preserve related query intent fields in copyInternal.
- Reject V4-only virtual scan state when serializing with QueryV3.
- Reject V3 serialization when query intent cannot be represented safely.
- Add regression tests for continuation copy and unsupported downgrade behavior.

## Validation
- go test -count=1 ./nosqldb -run 'TestOpRequests/.*Query|Test.*Query.*Intent|Test.*Downgrade|Test.*Continuation'
- go test -count=1 ./nosqldb
- git diff --check