### PR TITLE
Validate prepared query metadata and snapshot bind variables

### DIFF
--- a/nosqldb/nson_serializer.go
+++ b/nosqldb/nson_serializer.go
@@ -1511,7 +1511,7 @@ func (req *QueryRequest) serialize(w proto.Writer, serialVersion int16, queryVer
 		if err = ns.writeField(PREPARED_QUERY, pstmt.statement); err != nil {
 			return
 		}
-		if err = ns.writeBindVariables(pstmt.bindVariables); err != nil {
+		if err = ns.writeBindVariables(req.getBindVariables()); err != nil {
 			return
 		}
 	} else {
@@ -2884,9 +2884,16 @@ func readDriverPlanInfo(arr []byte) (dpi *driverPlanInfo, err error) {
 				return nil, err
 			}
 
-			if name != nil {
-				dpi.externalVars[*name] = id
+			if name == nil {
+				return nil, nosqlerr.NewIllegalArgument("invalid external variable metadata: variable name cannot be nil")
 			}
+			if _, ok := dpi.externalVars[*name]; ok {
+				return nil, nosqlerr.NewIllegalArgument("duplicate external variable name %q", *name)
+			}
+			dpi.externalVars[*name] = id
+		}
+		if err = validateExternalVariables(dpi.externalVars, numVars); err != nil {
+			return nil, err
 		}
 	}
 

--- a/nosqldb/rcb.go
+++ b/nosqldb/rcb.go
@@ -183,8 +183,11 @@ func (rcb *runtimeControlBlock) getBaseTopology() *common.TopologyInfo {
 
 // getExternalVar retrieves the value of external variable associated with the
 // specified variable id from RCB.
-func (rcb *runtimeControlBlock) getExternalVar(varID int) types.FieldValue {
-	return rcb.externalVars[varID]
+func (rcb *runtimeControlBlock) getExternalVar(varID int) (types.FieldValue, error) {
+	if varID < 0 || varID >= len(rcb.externalVars) {
+		return nil, nosqlerr.NewIllegalState("invalid external variable id %d", varID)
+	}
+	return rcb.externalVars[varID], nil
 }
 
 // trace is used to trace the execution of query plans.
@@ -385,6 +388,7 @@ func newQueryDriver(req *QueryRequest) *queryDriver {
 		request:   req,
 		batchSize: batchSize,
 	}
+	req.bindVariables = cloneBindVariables(req.getBindVariables())
 
 	return req.driver
 }
@@ -451,7 +455,13 @@ func (d *queryDriver) compute(res *QueryResult) (err error) {
 
 	iter := prepStmt.driverQueryPlan
 	if d.rcb == nil {
-		d.rcb, err = newRCB(d, iter, prepStmt.numIterators, prepStmt.numRegisters, prepStmt.getBoundVarValues())
+		var externalVars []types.FieldValue
+		externalVars, err = prepStmt.getBoundVarValues(d.request.getBindVariables())
+		if err != nil {
+			return err
+		}
+
+		d.rcb, err = newRCB(d, iter, prepStmt.numIterators, prepStmt.numRegisters, externalVars)
 		if err != nil {
 			return err
 		}

--- a/nosqldb/request.go
+++ b/nosqldb/request.go
@@ -1691,6 +1691,11 @@ type QueryRequest struct {
 	// PreparedStatement specifies the prepared query statement.
 	PreparedStatement *PreparedStatement `json:"preparedStatement,omitempty"`
 
+	// bindVariables snapshots the prepared statement bind variables for an
+	// active advanced query. Internal continuation requests must use this
+	// snapshot rather than the mutable PreparedStatement bind variable map.
+	bindVariables map[string]interface{}
+
 	// LastWriteMetadata specifies the write metadata to use for the operation.
 	// This setting is optional and only applies if the query modifies or
 	// deletes any rows using an INSERT, UPDATE, UPSERT or DELETE statement.
@@ -1919,6 +1924,7 @@ func (r *QueryRequest) copyInternal() *QueryRequest {
 		Consistency:                r.Consistency,
 		Durability:                 r.Durability,
 		PreparedStatement:          r.PreparedStatement,
+		bindVariables:              cloneBindVariables(r.getBindVariables()),
 		driver:                     r.driver,
 		traceLevel:                 r.traceLevel,
 		TableName:                  r.TableName,
@@ -1956,6 +1962,16 @@ func (r *QueryRequest) checkSerialVersionSupported(serialVersion int16) error {
 	}
 
 	return nil
+}
+
+func (r *QueryRequest) getBindVariables() map[string]interface{} {
+	if r.bindVariables != nil {
+		return r.bindVariables
+	}
+	if r.PreparedStatement == nil {
+		return nil
+	}
+	return r.PreparedStatement.bindVariables
 }
 
 // hasDriver reports whether the QueryRequest is bound with a query driver.
@@ -2030,6 +2046,7 @@ func (r *QueryRequest) setContKey(contKey []byte) {
 	if r.driver != nil && !r.isInternal && contKey == nil {
 		r.driver.close()
 		r.driver = nil
+		r.bindVariables = nil
 	}
 }
 
@@ -2128,6 +2145,12 @@ func newPreparedStatement(sqlText, queryPlan string,
 		return nil, nosqlerr.NewIllegalArgument("invalid prepared query, cannot be nil")
 	}
 
+	if driverPlan != nil {
+		if err := validatePreparedStatementMetadata(numIterators, numRegisters, variableToIDs); err != nil {
+			return nil, err
+		}
+	}
+
 	return &PreparedStatement{
 		sqlText:         sqlText,
 		queryPlan:       queryPlan,
@@ -2161,21 +2184,76 @@ func (p *PreparedStatement) isSimpleQuery() bool {
 	return p.driverQueryPlan == nil
 }
 
-func (p *PreparedStatement) getBoundVarValues() []types.FieldValue {
-	n := len(p.bindVariables)
-	if n == 0 {
+func (p *PreparedStatement) getBoundVarValues(bindVariables map[string]interface{}) ([]types.FieldValue, error) {
+	if len(bindVariables) == 0 {
+		if len(p.variableToIDs) == 0 {
+			return nil, nil
+		}
+		return make([]types.FieldValue, len(p.variableToIDs)), nil
+	}
+
+	values := make([]types.FieldValue, len(p.variableToIDs))
+	for k, v := range bindVariables {
+		id, ok := p.variableToIDs[k]
+		if !ok {
+			return nil, nosqlerr.NewIllegalArgument("the query does not contain the variable %s", k)
+		}
+		if id < 0 || id >= len(values) {
+			return nil, nosqlerr.NewIllegalState("invalid external variable id %d for variable %q", id, k)
+		}
+		values[id] = v
+	}
+
+	return values, nil
+}
+
+func validatePreparedStatementMetadata(numIterators, numRegisters int, variableToIDs map[string]int) error {
+	if err := validateStructuralCount(numIterators, "iterators"); err != nil {
+		return err
+	}
+	if err := validateStructuralCount(numRegisters, "registers"); err != nil {
+		return err
+	}
+	return validateExternalVariables(variableToIDs, len(variableToIDs))
+}
+
+func validateExternalVariables(variableToIDs map[string]int, numVars int) error {
+	if err := validateStructuralCount(numVars, "external variables"); err != nil {
+		return err
+	}
+	if len(variableToIDs) != numVars {
+		return nosqlerr.NewIllegalArgument("invalid external variable metadata: got %d variables, expected %d",
+			len(variableToIDs), numVars)
+	}
+
+	seenIDs := make(map[int]string, len(variableToIDs))
+	for name, id := range variableToIDs {
+		if name == "" {
+			return nosqlerr.NewIllegalArgument("invalid external variable metadata: variable name cannot be empty")
+		}
+		if id < 0 || id >= numVars {
+			return nosqlerr.NewIllegalArgument("invalid external variable id %d for variable %q", id, name)
+		}
+		if other, ok := seenIDs[id]; ok {
+			return nosqlerr.NewIllegalArgument("duplicate external variable id %d for variables %q and %q",
+				id, other, name)
+		}
+		seenIDs[id] = name
+	}
+
+	return nil
+}
+
+func cloneBindVariables(bindVariables map[string]interface{}) map[string]interface{} {
+	if len(bindVariables) == 0 {
 		return nil
 	}
 
-	values := make([]types.FieldValue, n)
-	for k, v := range p.bindVariables {
-		id, ok := p.variableToIDs[k]
-		if ok && id < n {
-			values[id] = v
-		}
+	clone := make(map[string]interface{}, len(bindVariables))
+	for k, v := range bindVariables {
+		clone[k] = v
 	}
-
-	return values
+	return clone
 }
 
 // GetQueryPlan returns the string (JSON) representation of the

--- a/nosqldb/request_test.go
+++ b/nosqldb/request_test.go
@@ -151,6 +151,58 @@ func TestQueryRequestRejectsSerialV3UnsupportedIntent(t *testing.T) {
 	}
 }
 
+func TestValidateExternalVariablesRejectsInvalidMetadata(t *testing.T) {
+	tests := []struct {
+		name        string
+		numVars     int
+		variableIDs map[string]int
+	}{
+		{
+			name:        "negative count",
+			numVars:     -1,
+			variableIDs: map[string]int{},
+		},
+		{
+			name:        "huge count",
+			numVars:     maxStructuralCount + 1,
+			variableIDs: map[string]int{},
+		},
+		{
+			name:        "empty name",
+			numVars:     1,
+			variableIDs: map[string]int{"": 0},
+		},
+		{
+			name:        "negative id",
+			numVars:     1,
+			variableIDs: map[string]int{"$a": -1},
+		},
+		{
+			name:        "out of range id",
+			numVars:     1,
+			variableIDs: map[string]int{"$a": 1},
+		},
+		{
+			name:        "duplicate id",
+			numVars:     2,
+			variableIDs: map[string]int{"$a": 0, "$b": 0},
+		},
+		{
+			name:        "missing variable",
+			numVars:     2,
+			variableIDs: map[string]int{"$a": 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateExternalVariables(tt.variableIDs, tt.numVars); err == nil {
+				t.Fatal("expected invalid external variable metadata to be rejected")
+			}
+		})
+	}
+}
+
 func TestQueryRequestSerialV3AllowsRepresentableIntent(t *testing.T) {
 	req := &QueryRequest{
 		Statement:   "select * from T1",
@@ -162,6 +214,84 @@ func TestQueryRequestSerialV3AllowsRepresentableIntent(t *testing.T) {
 
 	if err := req.serializeV3(binary.NewWriter(), 3); err != nil {
 		t.Fatalf("serializeV3() got unexpected error: %v", err)
+	}
+}
+
+func TestPreparedStatementGetBoundVarValuesValidatesIDs(t *testing.T) {
+	prep := &PreparedStatement{
+		variableToIDs: map[string]int{
+			"$a": 1,
+			"$b": 0,
+		},
+	}
+	values, err := prep.getBoundVarValues(map[string]interface{}{
+		"$a": int64(10),
+		"$b": int64(20),
+	})
+	if err != nil {
+		t.Fatalf("getBoundVarValues returned unexpected error: %v", err)
+	}
+	if got, want := values[0], types.FieldValue(int64(20)); got != want {
+		t.Fatalf("values[0] = %v, want %v", got, want)
+	}
+	if got, want := values[1], types.FieldValue(int64(10)); got != want {
+		t.Fatalf("values[1] = %v, want %v", got, want)
+	}
+
+	if _, err = prep.getBoundVarValues(map[string]interface{}{"$unknown": int64(1)}); err == nil {
+		t.Fatal("expected unknown bind variable to be rejected")
+	}
+
+	prep.variableToIDs["$bad"] = -1
+	if _, err = prep.getBoundVarValues(map[string]interface{}{"$bad": int64(1)}); err == nil {
+		t.Fatal("expected invalid bind variable id to be rejected")
+	}
+}
+
+func TestRuntimeControlBlockRejectsInvalidExternalVariableID(t *testing.T) {
+	rcb := &runtimeControlBlock{
+		externalVars: []types.FieldValue{int64(1)},
+	}
+
+	if _, err := rcb.getExternalVar(-1); err == nil {
+		t.Fatal("expected negative external variable id to be rejected")
+	}
+	if _, err := rcb.getExternalVar(1); err == nil {
+		t.Fatal("expected out of range external variable id to be rejected")
+	}
+}
+
+func TestQueryRequestSnapshotsBindVariablesForActiveAdvancedQuery(t *testing.T) {
+	prep := &PreparedStatement{
+		bindVariables: map[string]interface{}{
+			"$id": int64(10),
+		},
+		variableToIDs: map[string]int{
+			"$id": 0,
+		},
+	}
+	req := &QueryRequest{PreparedStatement: prep}
+
+	newQueryDriver(req)
+	if got, want := req.getBindVariables()["$id"], interface{}(int64(10)); got != want {
+		t.Fatalf("snapshot value = %v, want %v", got, want)
+	}
+
+	if err := prep.SetVariable("$id", int64(20)); err != nil {
+		t.Fatalf("SetVariable returned unexpected error: %v", err)
+	}
+	if got, want := req.getBindVariables()["$id"], interface{}(int64(10)); got != want {
+		t.Fatalf("active query bind snapshot changed to %v, want %v", got, want)
+	}
+
+	internal := req.copyInternal()
+	if got, want := internal.getBindVariables()["$id"], interface{}(int64(10)); got != want {
+		t.Fatalf("internal continuation snapshot = %v, want %v", got, want)
+	}
+
+	internal.bindVariables["$id"] = int64(30)
+	if got, want := req.getBindVariables()["$id"], interface{}(int64(10)); got != want {
+		t.Fatalf("internal continuation mutated parent snapshot to %v, want %v", got, want)
 	}
 }
 

--- a/nosqldb/v3_serializer.go
+++ b/nosqldb/v3_serializer.go
@@ -905,15 +905,24 @@ func deserializeV3PrepStmt(r proto.Reader, sqlText string, getQueryPlan bool) (p
 		if err != nil {
 			return
 		}
+		if err = validateStructuralCount(numIterators, "iterators"); err != nil {
+			return
+		}
 
 		numRegisters, err = r.ReadInt()
 		if err != nil {
+			return
+		}
+		if err = validateStructuralCount(numRegisters, "registers"); err != nil {
 			return
 		}
 
 		var numVars int
 		numVars, err = r.ReadInt()
 		if err != nil {
+			return
+		}
+		if err = validateStructuralCount(numVars, "external variables"); err != nil {
 			return
 		}
 
@@ -932,9 +941,18 @@ func deserializeV3PrepStmt(r proto.Reader, sqlText string, getQueryPlan bool) (p
 					return
 				}
 
-				if name != nil {
-					extVariables[*name] = id
+				if name == nil {
+					err = nosqlerr.NewIllegalArgument("invalid external variable metadata: variable name cannot be nil")
+					return
 				}
+				if _, ok := extVariables[*name]; ok {
+					err = nosqlerr.NewIllegalArgument("duplicate external variable name %q", *name)
+					return
+				}
+				extVariables[*name] = id
+			}
+			if err = validateExternalVariables(extVariables, numVars); err != nil {
+				return
 			}
 		}
 
@@ -1048,7 +1066,8 @@ func (req *QueryRequest) serializeV3(w proto.Writer, serialVersion int16) (err e
 		return
 	}
 
-	n := len(pstmt.bindVariables)
+	bindVariables := req.getBindVariables()
+	n := len(bindVariables)
 	if n <= 0 {
 		// bind variables is nil
 		_, err = w.WritePackedInt(0)
@@ -1059,7 +1078,7 @@ func (req *QueryRequest) serializeV3(w proto.Writer, serialVersion int16) (err e
 		return
 	}
 
-	for k, v := range pstmt.bindVariables {
+	for k, v := range bindVariables {
 		if _, err = w.WriteString(&k); err != nil {
 			return
 		}

--- a/nosqldb/values_iter.go
+++ b/nosqldb/values_iter.go
@@ -143,7 +143,10 @@ func (iter *extVarRefIter) next(rcb *runtimeControlBlock) (bool, error) {
 		return false, nil
 	}
 
-	value := rcb.getExternalVar(iter.id)
+	value, err := rcb.getExternalVar(iter.id)
+	if err != nil {
+		return false, err
+	}
 	if value == nil {
 		return false, nosqlerr.NewIllegalState("the external variable %q has not been set", iter.name)
 	}


### PR DESCRIPTION
## Summary
Validates prepared query metadata and snapshots bind variables so active advanced query execution cannot be affected by invalid server metadata or later caller mutations.

## Changes
- Validate prepared statement iterator/register counts before using them.
- Reject invalid external variable metadata, including negative counts, huge counts, empty names, duplicate IDs, and out-of-range IDs.
- Reject invalid external variable references during runtime lookup.
- Snapshot prepared statement bind variables when an advanced query starts.
- Preserve the bind-variable snapshot in internal continuation requests.
- Serialize prepared query continuations from the stable request snapshot instead of the mutable PreparedStatement.
- Add regression tests for metadata validation, invalid variable IDs, and bind-variable snapshot behavior.

## Validation
- go test -count=1 ./nosqldb -run 'Test(ValidateExternalVariables|PreparedStatementGetBoundVarValues|RuntimeControlBlockRejects|QueryRequestSnapshots|QueryRequestCopyInternal|QueryRequestRejects|QueryRequestSerialV3)'
- go test -count=1 ./nosqldb
- git diff --check