### PR TITLE
Avoid lazy advanced query close-before-RCB panic

### DIFF
--- a/nosqldb/client_test.go
+++ b/nosqldb/client_test.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -27,6 +28,96 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type closeTrackingPlanIter struct {
+	closeCalled bool
+}
+
+func (iter *closeTrackingPlanIter) open(rcb *runtimeControlBlock) error {
+	return nil
+}
+
+func (iter *closeTrackingPlanIter) next(rcb *runtimeControlBlock) (bool, error) {
+	return false, nil
+}
+
+func (iter *closeTrackingPlanIter) close(rcb *runtimeControlBlock) error {
+	if rcb == nil {
+		panic("plan iterator closed with nil runtime control block")
+	}
+	iter.closeCalled = true
+	return nil
+}
+
+func (iter *closeTrackingPlanIter) reset(rcb *runtimeControlBlock) error {
+	return nil
+}
+
+func (iter *closeTrackingPlanIter) getResult(rcb *runtimeControlBlock) types.FieldValue {
+	return nil
+}
+
+func (iter *closeTrackingPlanIter) setResult(rcb *runtimeControlBlock, val types.FieldValue) {
+}
+
+func (iter *closeTrackingPlanIter) getKind() planIterKind {
+	return constRef
+}
+
+func (iter *closeTrackingPlanIter) getState(rcb *runtimeControlBlock) planIterState {
+	return nil
+}
+
+func (iter *closeTrackingPlanIter) getPlan() string {
+	return ""
+}
+
+func (iter *closeTrackingPlanIter) displayContent(sb *strings.Builder, f *planFormatter) {
+}
+
+func TestLazyAdvancedQueryCloseBeforeRCBInitDoesNotPanic(t *testing.T) {
+	client, err := newMockClient()
+	require.NoError(t, err)
+
+	iter := &closeTrackingPlanIter{}
+	req := &QueryRequest{
+		PreparedStatement: &PreparedStatement{
+			statement:       bytes.Repeat([]byte{1}, minSerializedStmtLen),
+			driverQueryPlan: iter,
+		},
+	}
+
+	res, err := client.Query(req)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, req.driver)
+	require.Nil(t, req.driver.rcb)
+
+	require.NotPanics(t, func() {
+		req.Close()
+	})
+	require.False(t, iter.closeCalled, "plan close should not run before RCB initialization")
+	require.Nil(t, req.driver)
+}
+
+func TestAdvancedQueryCloseWithRCBCleansUpPlan(t *testing.T) {
+	iter := &closeTrackingPlanIter{}
+	req := &QueryRequest{
+		PreparedStatement: &PreparedStatement{
+			driverQueryPlan: iter,
+		},
+	}
+	req.driver = &queryDriver{
+		request: req,
+		rcb:     &runtimeControlBlock{},
+	}
+
+	require.NotPanics(t, func() {
+		req.Close()
+	})
+	require.True(t, iter.closeCalled, "plan close should run after RCB initialization")
+	require.Nil(t, req.driver)
+}
 
 func TestExecuteErrorHandling(t *testing.T) {
 	client, err := newMockClient()

--- a/nosqldb/rcb.go
+++ b/nosqldb/rcb.go
@@ -413,7 +413,7 @@ func (d *queryDriver) setQueryResult(res *QueryResult) {
 // close terminates query execution.
 func (d *queryDriver) close() {
 	prepStmt := d.request.PreparedStatement
-	if prepStmt != nil && prepStmt.driverQueryPlan != nil {
+	if prepStmt != nil && prepStmt.driverQueryPlan != nil && d.rcb != nil {
 		prepStmt.driverQueryPlan.close(d.rcb)
 	}
 


### PR DESCRIPTION
## Summary
Prevents lazy advanced query cleanup from panicking when QueryRequest.Close is called before the runtime control block is initialized.

## Changes
- Guard query driver cleanup so plan close is only called after the RCB exists.
- Preserve normal cleanup behavior for advanced queries that have already initialized the RCB.
- Add regression coverage for closing a lazy advanced query immediately after Query returns.
- Add regression coverage confirming plan cleanup still runs after RCB initialization.

## Validation
- go test -count=1 ./nosqldb -run 'TestLazyAdvancedQueryCloseBeforeRCBInitDoesNotPanic|TestAdvancedQueryCloseWithRCBCleansUpPlan'
- go test -count=1 ./nosqldb
- git diff --check