### PR TITLE
Reject QueryRequest with both Statement and PreparedStatement

### DIFF
--- a/nosqldb/request.go
+++ b/nosqldb/request.go
@@ -1851,6 +1851,10 @@ func (r *QueryRequest) validate() (err error) {
 		return nosqlerr.NewIllegalArgument("QueryRequest: either Statement or PreparedStatement should be set")
 	}
 
+	if r.Statement != "" && r.PreparedStatement != nil {
+		return nosqlerr.NewIllegalArgument("QueryRequest: Statement and PreparedStatement cannot both be set")
+	}
+
 	if r.LastWriteMetadata != "" {
 		if err = validateRowMetadata(r.LastWriteMetadata); err != nil {
 			return

--- a/nosqldb/request_test.go
+++ b/nosqldb/request_test.go
@@ -220,6 +220,53 @@ func (suite *RequestTestSuite) TestValidateTableName() {
 	}
 }
 
+func (suite *RequestTestSuite) TestValidateQueryRequestSource() {
+	prepStmt := &PreparedStatement{}
+	tests := []struct {
+		name string
+		req  *QueryRequest
+		want error
+	}{
+		{
+			name: "neither statement nor prepared statement",
+			req:  &QueryRequest{Timeout: time.Millisecond, Consistency: types.Absolute},
+			want: nosqlerr.NewIllegalArgument("QueryRequest: either Statement or PreparedStatement should be set"),
+		},
+		{
+			name: "both statement and prepared statement",
+			req: &QueryRequest{
+				Statement:         "select * from users",
+				PreparedStatement: prepStmt,
+				Timeout:           time.Millisecond,
+				Consistency:       types.Absolute,
+			},
+			want: nosqlerr.NewIllegalArgument("QueryRequest: Statement and PreparedStatement cannot both be set"),
+		},
+		{
+			name: "only statement",
+			req: &QueryRequest{
+				Statement:   "select * from users",
+				Timeout:     time.Millisecond,
+				Consistency: types.Absolute,
+			},
+		},
+		{
+			name: "only prepared statement",
+			req: &QueryRequest{
+				PreparedStatement: prepStmt,
+				Timeout:           time.Millisecond,
+				Consistency:       types.Absolute,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			suite.Equal(tt.want, tt.req.validate())
+		})
+	}
+}
+
 func (suite *RequestTestSuite) TestValidateKey() {
 	tests := []struct {
 		key  *types.MapValue


### PR DESCRIPTION
## Summary
Rejects QueryRequest configurations that set both Statement and PreparedStatement, matching the documented requirement that exactly one query source must be used.

## Changes
- Add QueryRequest validation for the both-set Statement and PreparedStatement case.
- Preserve existing validation for the neither-set case.
- Keep Statement-only QueryRequest valid.
- Keep PreparedStatement-only QueryRequest valid.
- Prevent serializers from silently ignoring Statement when PreparedStatement is also set.
- Add regression tests for all four query source combinations.

## Validation
- go test -count=1 ./nosqldb -run 'TestOpRequests/TestValidateQueryRequestSource'
- go test -count=1 ./nosqldb
- git diff --check