### PR TITLE
Support native struct requests in V3 fallback

### DIFF
--- a/nosqldb/v3_native_struct_test.go
+++ b/nosqldb/v3_native_struct_test.go
@@ -1,0 +1,129 @@
+//
+// Copyright (c) 2019, 2026 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Universal Permissive License v 1.0 as shown at
+//  https://oss.oracle.com/licenses/upl/
+//
+
+package nosqldb
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/oracle/nosql-go-sdk/nosqldb/internal/proto/binary"
+	"github.com/oracle/nosql-go-sdk/nosqldb/types"
+	"github.com/stretchr/testify/require"
+)
+
+type v3NativeStructRow struct {
+	ID   int    `nosql:"id"`
+	Name string `nosql:"name"`
+}
+
+func readV3TableOpHeader(t *testing.T, r *binary.Reader) {
+	t.Helper()
+
+	_, err := r.ReadByte()
+	require.NoError(t, err)
+	_, err = r.ReadPackedInt()
+	require.NoError(t, err)
+	tableName, err := r.ReadString()
+	require.NoError(t, err)
+	require.NotNil(t, tableName)
+}
+
+func TestGetRequestSerializeV3UsesStructValueAsKey(t *testing.T) {
+	req := &GetRequest{
+		TableName:   "users",
+		StructValue: &v3NativeStructRow{ID: 7, Name: "Ada"},
+		Timeout:     time.Second,
+		Consistency: types.Absolute,
+		StructType:  reflect.TypeOf((*v3NativeStructRow)(nil)).Elem(),
+	}
+	w := binary.NewWriter()
+
+	require.NoError(t, req.serializeV3(w, int16(3)))
+
+	r := binary.NewReader(bytes.NewBuffer(w.Bytes()))
+	readV3TableOpHeader(t, r)
+	_, err := r.ReadByte()
+	require.NoError(t, err)
+	key, err := r.ReadFieldValue()
+	require.NoError(t, err)
+	mv, ok := key.(*types.MapValue)
+	require.Truef(t, ok, "V3 Get key should serialize StructValue as MapValue, got %T", key)
+	id, ok := mv.Get("id")
+	require.True(t, ok)
+	require.Equal(t, int64(7), id)
+	name, ok := mv.Get("name")
+	require.True(t, ok)
+	require.Equal(t, "Ada", name)
+}
+
+func TestPutRequestSerializeV3UsesStructValueAsRow(t *testing.T) {
+	req := &PutRequest{
+		TableName:   "users",
+		StructValue: &v3NativeStructRow{ID: 7, Name: "Ada"},
+		Timeout:     time.Second,
+	}
+	w := binary.NewWriter()
+
+	require.NoError(t, req.serializeV3(w, int16(3)))
+
+	r := binary.NewReader(bytes.NewBuffer(w.Bytes()))
+	readV3TableOpHeader(t, r)
+	_, err := r.ReadBoolean()
+	require.NoError(t, err)
+	_, err = r.ReadByte()
+	require.NoError(t, err)
+	_, err = r.ReadBoolean()
+	require.NoError(t, err)
+	_, err = r.ReadPackedInt()
+	require.NoError(t, err)
+	value, err := r.ReadFieldValue()
+	require.NoError(t, err)
+	mv, ok := value.(*types.MapValue)
+	require.Truef(t, ok, "V3 Put row should serialize StructValue as MapValue, got %T", value)
+	id, ok := mv.Get("id")
+	require.True(t, ok)
+	require.Equal(t, int64(7), id)
+	name, ok := mv.Get("name")
+	require.True(t, ok)
+	require.Equal(t, "Ada", name)
+}
+
+func TestGetRequestDeserializeV3PopulatesStructValue(t *testing.T) {
+	req := &GetRequest{
+		StructType: reflect.TypeOf((*v3NativeStructRow)(nil)).Elem(),
+	}
+	row := types.NewMapValue(map[string]interface{}{
+		"id":   7,
+		"name": "Ada",
+	})
+	w := binary.NewWriter()
+	_, err := w.WritePackedInt(1)
+	require.NoError(t, err)
+	_, err = w.WritePackedInt(1)
+	require.NoError(t, err)
+	_, err = w.WritePackedInt(0)
+	require.NoError(t, err)
+	_, err = w.WriteBoolean(true)
+	require.NoError(t, err)
+	_, err = w.WriteFieldValue(row)
+	require.NoError(t, err)
+	_, err = w.WritePackedLong(0)
+	require.NoError(t, err)
+	_, err = w.WriteVersion(types.Version{1})
+	require.NoError(t, err)
+	_, err = w.WritePackedLong(123)
+	require.NoError(t, err)
+
+	res, err := req.deserializeV3(binary.NewReader(bytes.NewBuffer(w.Bytes())), int16(3))
+	require.NoError(t, err)
+	getRes := res.(*GetResult)
+	require.Nil(t, getRes.Value)
+	require.Equal(t, &v3NativeStructRow{ID: 7, Name: "Ada"}, getRes.StructValue)
+}

--- a/nosqldb/v3_serializer.go
+++ b/nosqldb/v3_serializer.go
@@ -10,11 +10,13 @@ package nosqldb
 import (
 	"errors"
 	"math/big"
+	"reflect"
 	"strings"
 	"time"
 
 	"github.com/oracle/nosql-go-sdk/nosqldb/common"
 	"github.com/oracle/nosql-go-sdk/nosqldb/internal/proto"
+	protobinary "github.com/oracle/nosql-go-sdk/nosqldb/internal/proto/binary"
 	"github.com/oracle/nosql-go-sdk/nosqldb/nosqlerr"
 	"github.com/oracle/nosql-go-sdk/nosqldb/types"
 )
@@ -39,8 +41,15 @@ func (req *GetRequest) serializeV3(w proto.Writer, serialVersion int16) (err err
 		return
 	}
 
-	if _, err = w.WriteFieldValue(req.Key); err != nil {
-		return
+	if req.Key != nil {
+		_, err = w.WriteFieldValue(req.Key)
+	} else if req.StructValue != nil {
+		_, err = w.WriteStructValue(req.StructValue)
+	} else {
+		err = errors.New("missing Key or StructValue in GetRequest")
+	}
+	if err != nil {
+		return err
 	}
 
 	return
@@ -68,7 +77,19 @@ func (req *GetRequest) deserializeV3(r proto.Reader, serialVersion int16) (Resul
 	}
 
 	if v, ok := v.(*types.MapValue); ok {
-		res.Value = v
+		if req.StructType != nil {
+			res.StructValue = reflect.New(req.StructType).Interface()
+			if err = protobinary.DecodeMapValue(res.StructValue, v); err != nil {
+				return nil, err
+			}
+		} else if req.StructValue != nil {
+			res.StructValue = req.StructValue
+			if err = protobinary.DecodeMapValue(res.StructValue, v); err != nil {
+				return nil, err
+			}
+		} else {
+			res.Value = v
+		}
 	}
 
 	timeMs, err := r.ReadPackedLong()
@@ -460,8 +481,15 @@ func (req *PutRequest) serializeV3(w proto.Writer, serialVersion int16) (err err
 		return
 	}
 
-	if _, err = w.WriteFieldValue(req.Value); err != nil {
-		return
+	if req.Value != nil {
+		_, err = w.WriteFieldValue(req.Value)
+	} else if req.StructValue != nil {
+		_, err = w.WriteStructValue(req.StructValue)
+	} else {
+		err = errors.New("missing Value or StructValue in PutRequest")
+	}
+	if err != nil {
+		return err
 	}
 
 	if _, err = w.WriteBoolean(req.updateTTL()); err != nil {


### PR DESCRIPTION
## Summary
Fixes native struct request behavior when the SDK falls back to V3 protocol serialization.

## Changes
- Serialize GetRequest StructValue as the V3 key when Key is not set.
- Serialize PutRequest StructValue as the V3 row value when Value is not set.
- Decode V3 Get responses into StructValue when StructType or StructValue is requested.
- Avoid silently serializing nil/null keys or rows during V3 fallback.
- Add regression tests for typed Get serialization, typed Put serialization, and typed Get response decoding under V3.

## Validation
- go test -count=1 ./nosqldb -run 'Test(GetRequestSerializeV3UsesStructValueAsKey|PutRequestSerializeV3UsesStructValueAsRow|GetRequestDeserializeV3PopulatesStructValue)'
- go test -count=1 ./nosqldb
- git diff --check