### PR TITLE
Fix federation auth retry error shadowing

### DIFF
--- a/nosqldb/auth/iam/federation_client.go
+++ b/nosqldb/auth/iam/federation_client.go
@@ -383,7 +383,8 @@ func (c *x509FederationClient) getSecurityToken() (securityToken, error) {
 	var err error
 
 	for retry := 0; retry < 5; retry++ {
-		httpRequest, err := c.makeHTTPRequest(request)
+		var httpRequest *http.Request
+		httpRequest, err = c.makeHTTPRequest(request)
 		if err != nil {
 			return nil, fmt.Errorf("failed to make http request: %s", err.Error())
 		}


### PR DESCRIPTION
## Summary
Fixes a regression from PR #61 where federation auth retry error handling could panic after repeated auth server failures.

## Changes
- Avoid err shadowing inside x509FederationClient.getSecurityToken retry loop.
- Preserve the authClient.Call error across retry attempts.
- Return a normal error after repeated auth server failures instead of reading from a nil response.
- Keep the fresh request body behavior from PR #61 unchanged.

## Validation
- go test -count=1 ./nosqldb/auth/iam -run TestX509FederationClient_AuthServerInternalError
- go test -count=1 ./nosqldb/auth/iam