### PR TITLE
Align query source validation with Java SDK

### DIFF
--- a/nosqldb/request.go
+++ b/nosqldb/request.go
@@ -1676,10 +1676,11 @@ var (
 	}
 )
 
-// QueryRequest encapsulates a query. A query may be either a string query
-// statement or a prepared query, which may include bind variables.
-// A query request cannot have both a string statement and prepared query, but
-// it must have one or the other.
+// QueryRequest encapsulates a query. A query must specify a string query
+// statement or a prepared query, which may include bind variables. During
+// execution the SDK may retain the string statement after it populates the
+// prepared query returned by the server. If both are present, they must
+// represent the same SQL text and the prepared query is used for execution.
 //
 // For performance reasons prepared queries are preferred for queries that may
 // be reused. Prepared queries bypass compilation of the query. They also allow
@@ -1856,8 +1857,9 @@ func (r *QueryRequest) validate() (err error) {
 		return nosqlerr.NewIllegalArgument("QueryRequest: either Statement or PreparedStatement should be set")
 	}
 
-	if r.Statement != "" && r.PreparedStatement != nil {
-		return nosqlerr.NewIllegalArgument("QueryRequest: Statement and PreparedStatement cannot both be set")
+	if r.Statement != "" && r.PreparedStatement != nil &&
+		r.Statement != r.PreparedStatement.sqlText {
+		return nosqlerr.NewIllegalArgument("QueryRequest: Statement does not match PreparedStatement SQL text")
 	}
 
 	if r.LastWriteMetadata != "" {

--- a/nosqldb/request_test.go
+++ b/nosqldb/request_test.go
@@ -8,6 +8,7 @@
 package nosqldb
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"testing"
@@ -351,7 +352,8 @@ func (suite *RequestTestSuite) TestValidateTableName() {
 }
 
 func (suite *RequestTestSuite) TestValidateQueryRequestSource() {
-	prepStmt := &PreparedStatement{}
+	const statement = "select * from users"
+	prepStmt := &PreparedStatement{sqlText: statement}
 	tests := []struct {
 		name string
 		req  *QueryRequest
@@ -363,19 +365,42 @@ func (suite *RequestTestSuite) TestValidateQueryRequestSource() {
 			want: nosqlerr.NewIllegalArgument("QueryRequest: either Statement or PreparedStatement should be set"),
 		},
 		{
-			name: "both statement and prepared statement",
+			name: "matching statement and prepared statement",
 			req: &QueryRequest{
-				Statement:         "select * from users",
+				Statement:         statement,
 				PreparedStatement: prepStmt,
 				Timeout:           time.Millisecond,
 				Consistency:       types.Absolute,
 			},
-			want: nosqlerr.NewIllegalArgument("QueryRequest: Statement and PreparedStatement cannot both be set"),
+		},
+		{
+			name: "conflicting statement and prepared statement",
+			req: &QueryRequest{
+				Statement: "select * from admins",
+				PreparedStatement: &PreparedStatement{
+					sqlText: statement,
+				},
+				Timeout:     time.Millisecond,
+				Consistency: types.Absolute,
+			},
+			want: nosqlerr.NewIllegalArgument("QueryRequest: Statement does not match PreparedStatement SQL text"),
+		},
+		{
+			name: "different statement text",
+			req: &QueryRequest{
+				Statement: "select  * from users",
+				PreparedStatement: &PreparedStatement{
+					sqlText: statement,
+				},
+				Timeout:     time.Millisecond,
+				Consistency: types.Absolute,
+			},
+			want: nosqlerr.NewIllegalArgument("QueryRequest: Statement does not match PreparedStatement SQL text"),
 		},
 		{
 			name: "only statement",
 			req: &QueryRequest{
-				Statement:   "select * from users",
+				Statement:   statement,
 				Timeout:     time.Millisecond,
 				Consistency: types.Absolute,
 			},
@@ -394,6 +419,64 @@ func (suite *RequestTestSuite) TestValidateQueryRequestSource() {
 		suite.Run(tt.name, func() {
 			suite.Equal(tt.want, tt.req.validate())
 		})
+	}
+}
+
+func TestQueryRequestMatchingSourcesUsePreparedSerialization(t *testing.T) {
+	const statement = "select * from users"
+	prepStmt := &PreparedStatement{
+		sqlText:   statement,
+		statement: []byte("prepared-query"),
+	}
+
+	preparedOnly := &QueryRequest{PreparedStatement: prepStmt}
+	matchingSources := &QueryRequest{
+		Statement:         statement,
+		PreparedStatement: prepStmt,
+	}
+
+	tests := []struct {
+		name      string
+		serialize func(*QueryRequest, proto.Writer) error
+	}{
+		{
+			name: "NSON",
+			serialize: func(req *QueryRequest, w proto.Writer) error {
+				return req.serialize(w, 4, 4)
+			},
+		},
+		{
+			name: "V3",
+			serialize: func(req *QueryRequest, w proto.Writer) error {
+				return req.serializeV3(w, 3)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			preparedWriter := binary.NewWriter()
+			if err := tt.serialize(preparedOnly, preparedWriter); err != nil {
+				t.Fatalf("serialize prepared-only request: %v", err)
+			}
+
+			matchingWriter := binary.NewWriter()
+			if err := tt.serialize(matchingSources, matchingWriter); err != nil {
+				t.Fatalf("serialize matching-source request: %v", err)
+			}
+
+			if !bytes.Equal(matchingWriter.Bytes(), preparedWriter.Bytes()) {
+				t.Fatal("matching-source request did not serialize as the prepared request")
+			}
+		})
+	}
+
+	internal := matchingSources.copyInternal()
+	if internal.Statement != "" {
+		t.Fatalf("copyInternal() Statement=%q, want empty", internal.Statement)
+	}
+	if internal.PreparedStatement != prepStmt {
+		t.Fatal("copyInternal() did not preserve PreparedStatement")
 	}
 }
 


### PR DESCRIPTION
## Summary
Aligns `QueryRequest` validation and execution behavior with the Java SDK while preserving compatibility with SDK-generated prepared query state.

## Changes
- Allow `Statement` and `PreparedStatement` when they represent the same SQL text.
- Reject requests when `Statement` conflicts with the prepared statement SQL text.
- Continue rejecting requests where neither query source is provided.
- Prefer prepared-query serialization when matching sources are present.
- Normalize internal continuation copies to retain only the prepared query state.
- Update API documentation to describe the supported runtime behavior.
- Add validation and serialization regression tests for NSON and V3 protocols.

## Validation
- `go test -count=1 -timeout 20m ./...`
- `go test -count=1 -timeout 20m -tags onprem ./nosqldb -run '^TestQuery$' -args testConfig=/private/tmp/onprem_8080_config.json`
- `go test -count=1 -timeout 20m -tags onprem ./... -args testConfig=/private/tmp/onprem_8080_config.json`
- `git diff --check`