### PR TITLE
perf: reduce request and response allocation pressure

### DIFF
--- a/nosqldb/client.go
+++ b/nosqldb/client.go
@@ -922,7 +922,7 @@ func (c *Client) nextRequestID() int32 {
 // processRequest processes the specified request before it is sent to server.
 // This method applies default configurations such as timeout and consistency
 // values for the request if they are not specified for the request.
-func (c *Client) processRequest(req Request) (data []byte, serialVerUsed int16, queryVerUsed int16, err error) {
+func (c *Client) processRequestLease(req Request) (lease *requestBufferLease, serialVerUsed int16, queryVerUsed int16, err error) {
 	if req == nil {
 		return nil, 0, 0, errNilRequest
 	}
@@ -943,17 +943,27 @@ func (c *Client) processRequest(req Request) (data []byte, serialVerUsed int16, 
 		return nil, 0, 0, err
 	}
 
-	data, serialVerUsed, queryVerUsed, err = c.serializeRequest(req)
+	lease, serialVerUsed, queryVerUsed, err = c.serializeRequestLease(req)
 	if err != nil || !c.isCloud {
 		return
 	}
 
 	// check request size for cloud
-	if err = checkRequestSizeLimit(req, len(data)); err != nil {
+	if err = checkRequestSizeLimit(req, len(lease.bytes())); err != nil {
+		lease.releaseOwner()
 		return nil, 0, 0, err
 	}
 
 	return
+}
+
+func (c *Client) processRequest(req Request) (data []byte, serialVerUsed int16, queryVerUsed int16, err error) {
+	lease, serialVerUsed, queryVerUsed, err := c.processRequestLease(req)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	defer lease.releaseOwner()
+	return append([]byte(nil), lease.bytes()...), serialVerUsed, queryVerUsed, nil
 }
 
 // Validates that all features required by the given request are enabled.
@@ -977,22 +987,30 @@ func (c *Client) execute(req Request) (Result, error) {
 }
 
 func (c *Client) executeWithContext(ctx context.Context, req Request) (Result, error) {
-	data, serialVerUsed, queryVerUsed, err := c.processRequest(req)
+	lease, serialVerUsed, queryVerUsed, err := c.processRequestLease(req)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.doExecute(ctx, req, data, serialVerUsed, queryVerUsed)
+	return c.doExecuteWithLease(ctx, req, lease, serialVerUsed, queryVerUsed)
 }
 
-func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serialVerUsed int16, queryVerUsed int16) (result Result, err error) {
+func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serialVerUsed int16, queryVerUsed int16) (Result, error) {
+	return c.doExecuteWithLease(ctx, req, newRequestBufferLeaseFromBytes(data), serialVerUsed, queryVerUsed)
+}
+
+func (c *Client) doExecuteWithLease(ctx context.Context, req Request, lease *requestBufferLease, serialVerUsed int16, queryVerUsed int16) (result Result, err error) {
+	if lease == nil {
+		return nil, errors.New("nil request buffer lease")
+	}
+	defer func() { lease.releaseOwner() }()
 	if req == nil {
 		return nil, errNilRequest
 	}
-
 	if ctx == nil {
 		return nil, errNilContext
 	}
+	data := lease.bytes()
 
 	statsControl := c.statsControl
 	statsEnabled := statsControl != nil && statsControl.isEnabled()
@@ -1210,7 +1228,15 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 					return nil, err
 				}
 				// if serial version mismatch, we must re-serialize the request
-				data, serialVerUsed, queryVerUsed, err = c.serializeRequest(req)
+				newLease, newSerialVersion, newQueryVersion, serializeErr := c.serializeRequestLease(req)
+				if serializeErr == nil {
+					lease.releaseOwner()
+					lease = newLease
+					data = lease.bytes()
+					serialVerUsed = newSerialVersion
+					queryVerUsed = newQueryVersion
+				}
+				err = serializeErr
 				if err != nil {
 					observeError()
 					return nil, err
@@ -1224,7 +1250,15 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 					return nil, err
 				}
 				// if query version mismatch, we must re-serialize the request
-				data, serialVerUsed, queryVerUsed, err = c.serializeRequest(req)
+				newLease, newSerialVersion, newQueryVersion, serializeErr := c.serializeRequestLease(req)
+				if serializeErr == nil {
+					lease.releaseOwner()
+					lease = newLease
+					data = lease.bytes()
+					serialVerUsed = newSerialVersion
+					queryVerUsed = newQueryVersion
+				}
+				err = serializeErr
 				if err != nil {
 					observeError()
 					return nil, err
@@ -1343,7 +1377,7 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 			continue
 		}
 
-		httpReq, err = httputil.NewPostRequest(c.requestURL, data)
+		httpReq, err = newLeasedPostRequest(c.requestURL, lease)
 		if err != nil {
 			observeError()
 			return nil, err
@@ -1352,7 +1386,7 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 		reqID := int(c.nextRequestID())
 		httpReq.Header.Add("x-nosql-request-id", strconv.Itoa(reqID))
 		httpReq.Header.Add("Host", c.serverHost)
-		httpReq.Header.Set("Content-Length", strconv.Itoa(len(data)))
+		httpReq.Header.Set("Content-Length", strconv.FormatInt(httpReq.ContentLength, 10))
 		httpReq.Header.Set("Content-Type", "application/octet-stream")
 		httpReq.Header.Set("Accept", "application/octet-stream")
 		httpReq.Header.Set("Connection", "keep-alive")
@@ -1378,6 +1412,7 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 
 		err = c.signHTTPRequest(httpReq)
 		if err != nil {
+			httpReq.Body.Close()
 			observeError()
 			return nil, err
 		}
@@ -1413,12 +1448,14 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 
 		reqCtx, reqCancel, deadlineErr := contextWithRemainingTimeout(reqTimeout, err)
 		if deadlineErr != nil {
+			httpReq.Body.Close()
 			observeError()
 			return nil, deadlineErr
 		}
 		httpReq = httpReq.WithContext(reqCtx)
 		requestStart := time.Now()
 		httpResp, err = c.executor.Do(httpReq)
+		httpReq.Body.Close()
 		if err != nil {
 			lastRequestLatency = time.Since(requestStart)
 			reqCancel()
@@ -1787,10 +1824,17 @@ func (c *Client) signHTTPRequest(httpReq *http.Request) error {
 // serializeRequest serializes the specified request into a slice of bytes that
 // will be sent to the server. The serial version is always written followed by
 // the actual request payload.
-func (c *Client) serializeRequest(req Request) (data []byte, serialVerUsed int16, queryVerUsed int16, err error) {
+func (c *Client) serializeRequestLease(req Request) (lease *requestBufferLease, serialVerUsed int16, queryVerUsed int16, err error) {
 	serialVerUsed = c.serialVersion
 	queryVerUsed = c.queryVersion
-	wr := binary.NewWriter()
+	lease = acquireRequestBufferLease()
+	wr := lease.writer
+	defer func() {
+		if err != nil {
+			lease.releaseOwner()
+			lease = nil
+		}
+	}()
 	if _, err = wr.WriteSerialVersion(serialVerUsed); err != nil {
 		return nil, 0, 0, err
 	}
@@ -1805,7 +1849,8 @@ func (c *Client) serializeRequest(req Request) (data []byte, serialVerUsed int16
 		}
 	}
 
-	return wr.Bytes(), serialVerUsed, queryVerUsed, nil
+	lease.data = wr.Bytes()
+	return lease, serialVerUsed, queryVerUsed, nil
 }
 
 // processResponse processes the http response returned from server.

--- a/nosqldb/client.go
+++ b/nosqldb/client.go
@@ -1015,7 +1015,7 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 
 	if queryReq, ok := req.(*QueryRequest); ok && !queryReq.isInternalRequest() {
 
-		req.SetTopology(c.getTopologyInfo())
+		req.SetTopology(c.topologySnapshot())
 
 		// If the QueryRequest represents an advanced query, it will be bound
 		// with a queryDriver the first time the execute() is called for the query.
@@ -1334,7 +1334,7 @@ func (c *Client) doExecute(ctx context.Context, req Request, data []byte, serial
 
 		// set the topology in the request, if not set already
 		if queryReq, ok := req.(*QueryRequest); !ok || queryReq.isInternalRequest() {
-			req.SetTopology(c.getTopologyInfo())
+			req.SetTopology(c.topologySnapshot())
 		}
 
 		// Handle errors that may occur when retrieving authorization string.
@@ -2205,11 +2205,16 @@ func (c *Client) decrementQueryVersion(queryVerUsed int16) bool {
 	return false
 }
 
-// getTopologyInfo returns the topology info stored in the client
-func (c *Client) getTopologyInfo() *common.TopologyInfo {
+// topologySnapshot returns the immutable topology currently published by the client.
+func (c *Client) topologySnapshot() *common.TopologyInfo {
 	c.topologyMux.RLock()
 	defer c.topologyMux.RUnlock()
-	return cloneTopologyInfo(c.topology)
+	return c.topology
+}
+
+// getTopologyInfo returns a mutable copy of the topology stored in the client.
+func (c *Client) getTopologyInfo() *common.TopologyInfo {
+	return cloneTopologyInfo(c.topologySnapshot())
 }
 
 // GetQueryVersion is used for tests.

--- a/nosqldb/client.go
+++ b/nosqldb/client.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -1462,10 +1461,11 @@ func (c *Client) doExecuteWithLease(ctx context.Context, req Request, lease *req
 			continue
 		}
 
-		var responseData []byte
-		responseData, err = readHTTPResponseBody(httpResp)
+		responseLease, readErr := readHTTPResponseBodyLease(httpResp)
 		lastRequestLatency = time.Since(requestStart)
+		responseData := responseLease.bytes()
 		lastResponseSize = len(responseData)
+		err = readErr
 		// Cancel request context after response body has been read.
 		reqCancel()
 		if err != nil {
@@ -1473,6 +1473,7 @@ func (c *Client) doExecuteWithLease(ctx context.Context, req Request, lease *req
 		}
 
 		result, err = c.handleResponse(responseData, httpResp, req, serialVerUsed, queryVerUsed)
+		responseLease.release()
 		if err != nil {
 			continue
 		}
@@ -1878,18 +1879,12 @@ func (c *Client) processResponse(data []byte, httpResp *http.Response, req Reque
 }
 
 func readHTTPResponseBody(httpResp *http.Response) ([]byte, error) {
-	if httpResp == nil {
-		return nil, nosqlerr.New(nosqlerr.UnknownError, "nil http response")
-	}
-	if httpResp.Body == nil {
-		return nil, nil
-	}
-	data, err := io.ReadAll(httpResp.Body)
-	httpResp.Body.Close()
+	lease, err := readHTTPResponseBodyLease(httpResp)
 	if err != nil {
 		return nil, err
 	}
-	return data, nil
+	defer lease.release()
+	return append([]byte(nil), lease.bytes()...), nil
 }
 
 func rateLimitDelayFromHeader(header http.Header) time.Duration {
@@ -1911,7 +1906,8 @@ func rateLimitDelayFromHeader(header http.Header) time.Duration {
 
 func (c *Client) processOKResponse(data []byte, req Request, serialVerUsed int16, queryVerUsed int16) (res Result, err error) {
 	buf := bytes.NewBuffer(data)
-	rd := binary.NewReader(buf)
+	rd := binary.GetReader(buf)
+	defer binary.PutReader(rd)
 
 	var code int
 	if serialVerUsed >= 4 {

--- a/nosqldb/client_test.go
+++ b/nosqldb/client_test.go
@@ -672,6 +672,49 @@ func TestTopologyInfoIsCloned(t *testing.T) {
 	require.Equal(t, []int{1, 2, 3}, ti.ShardIDs)
 }
 
+func TestTopologySnapshotRemainsImmutable(t *testing.T) {
+	client, err := newMockClient()
+	require.NoError(t, err)
+
+	client.setTopologyInfo(&common.TopologyInfo{SeqNum: 1, ShardIDs: []int{1, 2, 3}})
+	old := client.topologySnapshot()
+	client.setTopologyInfo(&common.TopologyInfo{SeqNum: 2, ShardIDs: []int{4, 5, 6}})
+
+	require.Equal(t, 1, old.SeqNum)
+	require.Equal(t, []int{1, 2, 3}, old.ShardIDs)
+	require.Equal(t, 2, client.topologySnapshot().SeqNum)
+}
+
+func TestTopologyInfoEqualsDoesNotMutate(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  *common.TopologyInfo
+		right *common.TopologyInfo
+		equal bool
+	}{
+		{"same values different order", &common.TopologyInfo{SeqNum: 1, ShardIDs: []int{3, 1, 2}}, &common.TopologyInfo{SeqNum: 1, ShardIDs: []int{2, 3, 1}}, true},
+		{"duplicates equal", &common.TopologyInfo{SeqNum: 1, ShardIDs: []int{1, 1, 2}}, &common.TopologyInfo{SeqNum: 1, ShardIDs: []int{2, 1, 1}}, true},
+		{"duplicates differ", &common.TopologyInfo{SeqNum: 1, ShardIDs: []int{1, 1, 2}}, &common.TopologyInfo{SeqNum: 1, ShardIDs: []int{1, 2, 2}}, false},
+		{"nil and empty differ", &common.TopologyInfo{SeqNum: 1}, &common.TopologyInfo{SeqNum: 1, ShardIDs: []int{}}, false},
+		{"sequence differs", &common.TopologyInfo{SeqNum: 1, ShardIDs: []int{1}}, &common.TopologyInfo{SeqNum: 2, ShardIDs: []int{1}}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var leftBefore, rightBefore []int
+			if tc.left.ShardIDs != nil {
+				leftBefore = append([]int{}, tc.left.ShardIDs...)
+			}
+			if tc.right.ShardIDs != nil {
+				rightBefore = append([]int{}, tc.right.ShardIDs...)
+			}
+			require.Equal(t, tc.equal, tc.left.Equals(tc.right))
+			require.Equal(t, leftBefore, tc.left.ShardIDs)
+			require.Equal(t, rightBefore, tc.right.ShardIDs)
+		})
+	}
+}
+
 func newMockClient() (*Client, error) {
 	authProvider := &DummyAccessTokenProvider{
 		TenantID: "TestTenantId",

--- a/nosqldb/common/internal_data.go
+++ b/nosqldb/common/internal_data.go
@@ -8,8 +8,6 @@
 package common
 
 import (
-	"reflect"
-	"sort"
 	"time"
 )
 
@@ -123,10 +121,21 @@ func (ti *TopologyInfo) Equals(otherTopo *TopologyInfo) bool {
 		return false
 	}
 
-	// Sort the slice of shard IDs and compare.
-	sort.Ints(ti.ShardIDs)
-	sort.Ints(otherTopo.ShardIDs)
-	return reflect.DeepEqual(ti.ShardIDs, otherTopo.ShardIDs)
+	if (ti.ShardIDs == nil) != (otherTopo.ShardIDs == nil) {
+		return false
+	}
+
+	counts := make(map[int]int, len(ti.ShardIDs))
+	for _, shardID := range ti.ShardIDs {
+		counts[shardID]++
+	}
+	for _, shardID := range otherTopo.ShardIDs {
+		if counts[shardID] == 0 {
+			return false
+		}
+		counts[shardID]--
+	}
+	return true
 }
 
 // GetTopologyInfo returns the entire topology info

--- a/nosqldb/internal/proto/binary/reader.go
+++ b/nosqldb/internal/proto/binary/reader.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"math"
 	"math/big"
+	"sync"
 	"unicode/utf8"
 
 	"github.com/oracle/nosql-go-sdk/nosqldb/types"
@@ -28,6 +29,12 @@ const maxCollectionElements int = 1 << 20
 // proxy and drivers.
 //
 // Reader implements the io.Reader and io.ByteReader interfaces.
+const maxPooledReaderBufferCapacity = 64 * 1024
+
+var readerPool = sync.Pool{New: func() interface{} {
+	return NewReader(new(bytes.Buffer))
+}}
+
 type Reader struct {
 	// The underlying io.Reader.
 	rd *bytes.Buffer
@@ -41,6 +48,29 @@ func NewReader(r *bytes.Buffer) *Reader {
 	return &Reader{
 		rd:  r,
 		buf: make([]byte, 64, 256),
+	}
+}
+
+// GetReader obtains a reset binary reader for the supplied buffer.
+func GetReader(buf *bytes.Buffer) *Reader {
+	r := readerPool.Get().(*Reader)
+	r.rd = buf
+	if cap(r.buf) < 64 {
+		r.buf = make([]byte, 64, 256)
+	} else {
+		r.buf = r.buf[:64]
+	}
+	return r
+}
+
+// PutReader releases a reader obtained from GetReader.
+func PutReader(r *Reader) {
+	if r == nil {
+		return
+	}
+	r.rd = nil
+	if cap(r.buf) <= maxPooledReaderBufferCapacity {
+		readerPool.Put(r)
 	}
 }
 

--- a/nosqldb/internal/proto/binary/reader.go
+++ b/nosqldb/internal/proto/binary/reader.go
@@ -175,6 +175,13 @@ func (r *Reader) ReadString() (*string, error) {
 		return nil, err
 	}
 
+	if utf8.Valid(buf) {
+		s := string(buf)
+		return &s, nil
+	}
+
+	// Preserve the existing behavior for malformed UTF-8 by replacing each
+	// invalid sequence with RuneError.
 	cnt := utf8.RuneCount(buf)
 	runeBuf := make([]rune, cnt)
 	for i := 0; i < cnt && len(buf) > 0; i++ {
@@ -223,7 +230,7 @@ func (r *Reader) ReadMap() (*types.MapValue, error) {
 		return nil, err
 	}
 
-	value := types.NewOrderedMapValue()
+	value := types.NewOrderedMapValueWithCapacity(size)
 	for i := 0; i < size; i++ {
 		k, err := r.ReadString()
 		if err != nil {

--- a/nosqldb/internal/proto/binary/reader_test.go
+++ b/nosqldb/internal/proto/binary/reader_test.go
@@ -134,18 +134,27 @@ func BenchmarkReadDouble(b *testing.B) {
 	}
 }
 
+var benchmarkStringSink *string
+
 func BenchmarkReadString(b *testing.B) {
 	w := NewWriter()
 	s := "Oracle NoSQL Database"
 	w.WriteString(&s)
-	buf := w.Bytes()
-	r := NewReader(bytes.NewBuffer(buf))
+	buf := append([]byte(nil), w.Bytes()...)
+	input := bytes.NewBuffer(make([]byte, 0, len(buf)))
 	b.SetBytes(int64(len(buf)))
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		r.ReadString()
+		input.Reset()
+		input.Write(buf)
+		r := GetReader(input)
+		benchmarkStringSink, _ = r.ReadString()
+		PutReader(r)
 	}
 }
+
+var benchmarkMapSink *types.MapValue
 
 func BenchmarkReadMap(b *testing.B) {
 	w := NewWriter()
@@ -157,12 +166,17 @@ func BenchmarkReadMap(b *testing.B) {
 	mv.Put("array", []types.FieldValue{1, 2, 3, 4})
 	mv.Put("bytes", []byte{1, 2, 3, 4, 5, 6, 7, 8})
 	w.WriteMap(mv)
-	buf := w.Bytes()
-	r := NewReader(bytes.NewBuffer(buf))
+	buf := append([]byte(nil), w.Bytes()...)
+	input := bytes.NewBuffer(make([]byte, 0, len(buf)))
 	b.SetBytes(int64(len(buf)))
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		r.ReadMap()
+		input.Reset()
+		input.Write(buf)
+		r := GetReader(input)
+		benchmarkMapSink, _ = r.ReadMap()
+		PutReader(r)
 	}
 }
 

--- a/nosqldb/internal/proto/binary/rw_test.go
+++ b/nosqldb/internal/proto/binary/rw_test.go
@@ -10,12 +10,15 @@ package binary
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
+	"fmt"
 	"io"
 	"math"
 	"math/rand"
 	"reflect"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/oracle/nosql-go-sdk/nosqldb/types"
 	"github.com/stretchr/testify/suite"
@@ -627,4 +630,94 @@ func (suite *ReadWriteTestSuite) TestReadWriteStruct() {
 	_, err := r.ReadInt()
 	suite.Equalf(io.EOF, err, "ReadInt() got unexpected error")
 
+}
+
+func legacyWriteString(value *string) []byte {
+	w := NewWriter()
+	if value == nil {
+		w.WritePackedInt(-1)
+		return append([]byte(nil), w.Bytes()...)
+	}
+
+	runes := []rune(*value)
+	byteLen := 0
+	for _, r := range runes {
+		byteLen += utf8.RuneLen(r)
+	}
+	w.WritePackedInt(byteLen)
+	for _, r := range runes {
+		var encoded [utf8.UTFMax]byte
+		n := utf8.EncodeRune(encoded[:], r)
+		w.Write(encoded[:n])
+	}
+	return append([]byte(nil), w.Bytes()...)
+}
+
+func legacyReadString(r *Reader) (*string, error) {
+	byteLen, err := r.ReadPackedInt()
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case byteLen < -1:
+		return nil, errors.New("binary.Reader: invalid length of string")
+	case byteLen == -1:
+		return nil, nil
+	case byteLen == 0:
+		s := ""
+		return &s, nil
+	}
+	if err = r.validateRemainingLength(byteLen, "string"); err != nil {
+		return nil, err
+	}
+	buf, err := r.readFull(byteLen)
+	if err != nil {
+		return nil, err
+	}
+	cnt := utf8.RuneCount(buf)
+	runeBuf := make([]rune, cnt)
+	for i := 0; i < cnt && len(buf) > 0; i++ {
+		r, off := utf8.DecodeRune(buf)
+		runeBuf[i] = r
+		buf = buf[off:]
+	}
+	s := string(runeBuf)
+	return &s, nil
+}
+
+func FuzzWriteStringCompatibility(f *testing.F) {
+	for _, seed := range []string{"", "Oracle NoSQL", "multibyte", string([]byte{0xff, 0xfe, 0x61})} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, value string) {
+		w := NewWriter()
+		if _, err := w.WriteString(&value); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(w.Bytes(), legacyWriteString(&value)) {
+			t.Fatalf("wire output differs for %q", value)
+		}
+	})
+}
+
+func FuzzReadStringCompatibility(f *testing.F) {
+	f.Add([]byte{0})
+	f.Add([]byte{1, 0xff})
+	f.Add([]byte{3, 0xe2, 0x82, 0xac})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		newReader := NewReader(bytes.NewBuffer(append([]byte(nil), data...)))
+		oldReader := NewReader(bytes.NewBuffer(append([]byte(nil), data...)))
+		got, gotErr := newReader.ReadString()
+		want, wantErr := legacyReadString(oldReader)
+
+		if fmt.Sprint(gotErr) != fmt.Sprint(wantErr) {
+			t.Fatalf("error differs: got %v, want %v", gotErr, wantErr)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("value differs: got %v, want %v", got, want)
+		}
+		if newReader.GetBuffer().Len() != oldReader.GetBuffer().Len() {
+			t.Fatalf("reader position differs: got remaining %d, want %d", newReader.GetBuffer().Len(), oldReader.GetBuffer().Len())
+		}
+	})
 }

--- a/nosqldb/internal/proto/binary/writer.go
+++ b/nosqldb/internal/proto/binary/writer.go
@@ -153,12 +153,24 @@ func (w *Writer) WriteString(value *string) (n int, err error) {
 		return w.WritePackedInt(-1)
 	}
 
-	rs := []rune(*value)
-	byteLen := 0
-	for _, r := range rs {
-		byteLen += utf8.RuneLen(r)
+	s := *value
+	if utf8.ValidString(s) {
+		n, err = w.WritePackedInt(len(s))
+		if err != nil || len(s) == 0 {
+			return
+		}
+
+		off := w.ensure(len(s))
+		copy(w.buf[off:], s)
+		return n + len(s), nil
 	}
 
+	// Preserve the existing behavior for malformed UTF-8: each invalid byte is
+	// encoded as RuneError.
+	byteLen := 0
+	for _, r := range s {
+		byteLen += utf8.RuneLen(r)
+	}
 	n, err = w.WritePackedInt(byteLen)
 	if err != nil || byteLen == 0 {
 		return
@@ -166,7 +178,7 @@ func (w *Writer) WriteString(value *string) (n int, err error) {
 
 	off := w.ensure(byteLen)
 	startOff := off
-	for _, r := range rs {
+	for _, r := range s {
 		off += utf8.EncodeRune(w.buf[off:], r)
 	}
 	n += (off - startOff)

--- a/nosqldb/internal/proto/binary/writer_test.go
+++ b/nosqldb/internal/proto/binary/writer_test.go
@@ -91,6 +91,7 @@ func BenchmarkWriteString(b *testing.B) {
 	w := NewWriter()
 	str := "Oracle NoSQL Database"
 	b.SetBytes(int64(len(str)))
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		w.WriteString(&str)
@@ -131,6 +132,7 @@ func BenchmarkWriteMap(b *testing.B) {
 	mv.Put("bytes", []byte{1, 2, 3, 4, 5, 6, 7, 8})
 	n, _ := w.WriteMap(mv)
 	b.SetBytes(int64(n))
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		w.WriteMap(mv)

--- a/nosqldb/rcb.go
+++ b/nosqldb/rcb.go
@@ -151,7 +151,7 @@ func newRCB(driver *queryDriver, rootIter planIter, numIterators, numRegisters i
 		iterStates:   make([]planIterState, numIterators),
 		registers:    make([]types.FieldValue, numRegisters),
 		externalVars: externalVars,
-		baseTopology: driver.getClient().getTopologyInfo(),
+		baseTopology: driver.getClient().topologySnapshot(),
 	}, nil
 }
 

--- a/nosqldb/request_lease.go
+++ b/nosqldb/request_lease.go
@@ -1,3 +1,10 @@
+//
+// Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Universal Permissive License v 1.0 as shown at
+//  https://oss.oracle.com/licenses/upl/
+//
+
 package nosqldb
 
 import (

--- a/nosqldb/request_lease.go
+++ b/nosqldb/request_lease.go
@@ -1,0 +1,144 @@
+package nosqldb
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	"github.com/oracle/nosql-go-sdk/nosqldb/internal/proto/binary"
+)
+
+const maxPooledRequestBufferCapacity = 64 * 1024
+
+var (
+	errRequestLeaseReleased = errors.New("request buffer lease is released")
+	requestWriterPool       = sync.Pool{New: func() interface{} { return binary.NewWriter() }}
+)
+
+type requestBufferLease struct {
+	writer      *binary.Writer
+	data        []byte
+	refs        int32
+	ownerOnce   sync.Once
+	recycleOnce sync.Once
+}
+
+func acquireRequestBufferLease() *requestBufferLease {
+	writer := requestWriterPool.Get().(*binary.Writer)
+	writer.Reset()
+	return &requestBufferLease{writer: writer, refs: 1}
+}
+
+func newRequestBufferLeaseFromBytes(data []byte) *requestBufferLease {
+	lease := acquireRequestBufferLease()
+	_, _ = lease.writer.Write(data)
+	lease.data = lease.writer.Bytes()
+	return lease
+}
+
+func (l *requestBufferLease) bytes() []byte {
+	if l == nil {
+		return nil
+	}
+	return l.data
+}
+
+func (l *requestBufferLease) newBody() (io.ReadCloser, error) {
+	if l == nil {
+		return nil, errRequestLeaseReleased
+	}
+	for {
+		refs := atomic.LoadInt32(&l.refs)
+		if refs <= 0 {
+			return nil, errRequestLeaseReleased
+		}
+		if atomic.CompareAndSwapInt32(&l.refs, refs, refs+1) {
+			return &leaseBody{reader: bytes.NewReader(l.data), lease: l}, nil
+		}
+	}
+}
+
+func (l *requestBufferLease) releaseOwner() {
+	if l == nil {
+		return
+	}
+	l.ownerOnce.Do(l.releaseRef)
+}
+
+func (l *requestBufferLease) releaseRef() {
+	for {
+		refs := atomic.LoadInt32(&l.refs)
+		if refs <= 0 {
+			panic("nosqldb: request buffer lease reference underflow")
+		}
+		if !atomic.CompareAndSwapInt32(&l.refs, refs, refs-1) {
+			continue
+		}
+		if refs == 1 {
+			l.recycleOnce.Do(l.recycle)
+		}
+		return
+	}
+}
+
+func (l *requestBufferLease) recycle() {
+	writer := l.writer
+	data := l.data
+	l.data = nil
+	l.writer = nil
+	if writer == nil || cap(data) > maxPooledRequestBufferCapacity {
+		return
+	}
+	writer.Reset()
+	requestWriterPool.Put(writer)
+}
+
+func newLeasedPostRequest(url string, lease *requestBufferLease) (*http.Request, error) {
+	body, err := lease.newBody()
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, url, body)
+	if err != nil {
+		body.Close()
+		return nil, err
+	}
+	length := int64(len(lease.bytes()))
+	req.ContentLength = length
+	req.Header.Set("Content-Length", strconv.FormatInt(length, 10))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return lease.newBody()
+	}
+	return req, nil
+}
+
+type leaseBody struct {
+	reader *bytes.Reader
+	lease  *requestBufferLease
+	mu     sync.Mutex
+	closed bool
+	once   sync.Once
+}
+
+func (b *leaseBody) Read(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return 0, http.ErrBodyReadAfterClose
+	}
+	return b.reader.Read(p)
+}
+
+func (b *leaseBody) Close() error {
+	b.once.Do(func() {
+		b.mu.Lock()
+		b.closed = true
+		b.mu.Unlock()
+		b.lease.releaseRef()
+	})
+	return nil
+}

--- a/nosqldb/request_lease.go
+++ b/nosqldb/request_lease.go
@@ -140,6 +140,15 @@ func (b *leaseBody) Read(p []byte) (int, error) {
 	return b.reader.Read(p)
 }
 
+func (b *leaseBody) WriteTo(w io.Writer) (int64, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return 0, http.ErrBodyReadAfterClose
+	}
+	return b.reader.WriteTo(w)
+}
+
 func (b *leaseBody) Close() error {
 	b.once.Do(func() {
 		b.mu.Lock()

--- a/nosqldb/request_lease_test.go
+++ b/nosqldb/request_lease_test.go
@@ -1,3 +1,10 @@
+//
+// Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Universal Permissive License v 1.0 as shown at
+//  https://oss.oracle.com/licenses/upl/
+//
+
 package nosqldb
 
 import (

--- a/nosqldb/request_lease_test.go
+++ b/nosqldb/request_lease_test.go
@@ -1,0 +1,112 @@
+package nosqldb
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestLeaseHTTPMetadataAndReplay(t *testing.T) {
+	payload := []byte("request payload")
+	lease := newRequestBufferLeaseFromBytes(payload)
+	req, err := newLeasedPostRequest("http://localhost/request", lease)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(payload)), req.ContentLength)
+	require.Equal(t, strconv.Itoa(len(payload)), req.Header.Get("Content-Length"))
+
+	got, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+	require.NoError(t, req.Body.Close())
+
+	replay, err := req.GetBody()
+	require.NoError(t, err)
+	got, err = io.ReadAll(replay)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+	require.NoError(t, replay.Close())
+
+	lease.releaseOwner()
+	_, err = req.GetBody()
+	require.Equal(t, errRequestLeaseReleased, err)
+}
+
+func TestLeaseBodyReadAfterCloseAndDoubleClose(t *testing.T) {
+	lease := newRequestBufferLeaseFromBytes([]byte("payload"))
+	body, err := lease.newBody()
+	require.NoError(t, err)
+	require.NoError(t, body.Close())
+	require.NoError(t, body.Close())
+
+	_, err = body.Read(make([]byte, 1))
+	require.Equal(t, http.ErrBodyReadAfterClose, err)
+	lease.releaseOwner()
+	require.Equal(t, int32(0), atomic.LoadInt32(&lease.refs))
+}
+
+func TestLeaseBodyConcurrentReadAndClose(t *testing.T) {
+	lease := newRequestBufferLeaseFromBytes(bytes.Repeat([]byte("x"), 64*1024))
+	body, err := lease.newBody()
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 127)
+		for {
+			_, readErr := body.Read(buf)
+			if readErr == io.EOF || readErr == http.ErrBodyReadAfterClose {
+				return
+			}
+			require.NoError(t, readErr)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		require.NoError(t, body.Close())
+	}()
+	wg.Wait()
+	lease.releaseOwner()
+}
+
+func TestRequestLeaseDelayedBodyClosePreventsReuse(t *testing.T) {
+	payload := bytes.Repeat([]byte("first-request-"), 256)
+	lease := newRequestBufferLeaseFromBytes(payload)
+	body, err := lease.newBody()
+	require.NoError(t, err)
+	lease.releaseOwner()
+
+	writer := lease.writer
+	require.NotNil(t, writer)
+	for i := 0; i < 64; i++ {
+		pressure := newRequestBufferLeaseFromBytes(bytes.Repeat([]byte{byte(i)}, len(payload)))
+		if writer == pressure.writer {
+			t.Fatal("writer recycled while request body was still open")
+		}
+		pressure.releaseOwner()
+	}
+
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+	require.NotNil(t, lease.writer)
+	require.NoError(t, body.Close())
+	require.Nil(t, lease.writer)
+}
+
+func TestRequestLeaseReleaseGuards(t *testing.T) {
+	lease := newRequestBufferLeaseFromBytes([]byte("payload"))
+	lease.releaseOwner()
+	lease.releaseOwner()
+	require.Equal(t, int32(0), atomic.LoadInt32(&lease.refs))
+	_, err := lease.newBody()
+	require.Equal(t, errRequestLeaseReleased, err)
+	require.Panics(t, lease.releaseRef)
+}

--- a/nosqldb/request_lease_test.go
+++ b/nosqldb/request_lease_test.go
@@ -57,6 +57,26 @@ func TestLeaseBodyReadAfterCloseAndDoubleClose(t *testing.T) {
 	require.Equal(t, int32(0), atomic.LoadInt32(&lease.refs))
 }
 
+func TestLeaseBodyWriteToAndClose(t *testing.T) {
+	payload := bytes.Repeat([]byte("payload-"), 128)
+	lease := newRequestBufferLeaseFromBytes(payload)
+	body, err := lease.newBody()
+	require.NoError(t, err)
+
+	writerTo, ok := body.(io.WriterTo)
+	require.True(t, ok)
+	var got bytes.Buffer
+	n, err := writerTo.WriteTo(&got)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(payload)), n)
+	require.Equal(t, payload, got.Bytes())
+	require.NoError(t, body.Close())
+
+	_, err = writerTo.WriteTo(io.Discard)
+	require.Equal(t, http.ErrBodyReadAfterClose, err)
+	lease.releaseOwner()
+}
+
 func TestLeaseBodyConcurrentReadAndClose(t *testing.T) {
 	lease := newRequestBufferLeaseFromBytes(bytes.Repeat([]byte("x"), 64*1024))
 	body, err := lease.newBody()

--- a/nosqldb/response_lease.go
+++ b/nosqldb/response_lease.go
@@ -1,3 +1,10 @@
+//
+// Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Universal Permissive License v 1.0 as shown at
+//  https://oss.oracle.com/licenses/upl/
+//
+
 package nosqldb
 
 import (

--- a/nosqldb/response_lease.go
+++ b/nosqldb/response_lease.go
@@ -1,0 +1,63 @@
+package nosqldb
+
+import (
+	"bytes"
+	"net/http"
+	"sync"
+
+	"github.com/oracle/nosql-go-sdk/nosqldb/nosqlerr"
+)
+
+const maxPooledResponseBufferCapacity = 64 * 1024
+
+var responseBufferPool = sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
+
+type responseBufferLease struct {
+	buffer *bytes.Buffer
+	once   sync.Once
+}
+
+func acquireResponseBufferLease() *responseBufferLease {
+	buffer := responseBufferPool.Get().(*bytes.Buffer)
+	buffer.Reset()
+	return &responseBufferLease{buffer: buffer}
+}
+
+func (l *responseBufferLease) bytes() []byte {
+	if l == nil || l.buffer == nil {
+		return nil
+	}
+	return l.buffer.Bytes()
+}
+
+func (l *responseBufferLease) release() {
+	if l == nil {
+		return
+	}
+	l.once.Do(func() {
+		buffer := l.buffer
+		l.buffer = nil
+		if buffer == nil || buffer.Cap() > maxPooledResponseBufferCapacity {
+			return
+		}
+		buffer.Reset()
+		responseBufferPool.Put(buffer)
+	})
+}
+
+func readHTTPResponseBodyLease(httpResp *http.Response) (*responseBufferLease, error) {
+	if httpResp == nil {
+		return nil, nosqlerr.New(nosqlerr.UnknownError, "nil http response")
+	}
+	if httpResp.Body == nil {
+		return nil, nil
+	}
+	defer httpResp.Body.Close()
+
+	lease := acquireResponseBufferLease()
+	if _, err := lease.buffer.ReadFrom(httpResp.Body); err != nil {
+		lease.release()
+		return nil, err
+	}
+	return lease, nil
+}

--- a/nosqldb/response_lease_test.go
+++ b/nosqldb/response_lease_test.go
@@ -1,3 +1,10 @@
+//
+// Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Universal Permissive License v 1.0 as shown at
+//  https://oss.oracle.com/licenses/upl/
+//
+
 package nosqldb
 
 import (

--- a/nosqldb/response_lease_test.go
+++ b/nosqldb/response_lease_test.go
@@ -1,0 +1,84 @@
+package nosqldb
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/oracle/nosql-go-sdk/nosqldb/internal/proto/binary"
+	"github.com/oracle/nosql-go-sdk/nosqldb/types"
+	"github.com/stretchr/testify/require"
+)
+
+type trackedResponseBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *trackedResponseBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestResponseLeaseClosesBodyAndReleasesBuffer(t *testing.T) {
+	body := &trackedResponseBody{Reader: bytes.NewBufferString("response")}
+	lease, err := readHTTPResponseBodyLease(&http.Response{Body: body})
+	require.NoError(t, err)
+	require.True(t, body.closed)
+	require.Equal(t, []byte("response"), lease.bytes())
+	require.NotNil(t, lease.buffer)
+
+	lease.release()
+	require.Nil(t, lease.buffer)
+	lease.release()
+}
+
+func TestResponseValuesDoNotAliasPooledBuffer(t *testing.T) {
+	writer := binary.NewWriter()
+	value := types.NewOrderedMapValueWithCapacity(3)
+	value.Put("bytes", []byte{1, 2, 3, 4})
+	value.Put("nested", types.NewOrderedMapValue().Put("name", "value"))
+	value.Put("array", []types.FieldValue{"one", []byte{5, 6, 7}})
+	_, err := writer.WriteMap(value)
+	require.NoError(t, err)
+
+	lease, err := readHTTPResponseBodyLease(&http.Response{Body: io.NopCloser(bytes.NewReader(writer.Bytes()))})
+	require.NoError(t, err)
+	reader := binary.GetReader(bytes.NewBuffer(lease.bytes()))
+	decoded, err := reader.ReadMap()
+	binary.PutReader(reader)
+	require.NoError(t, err)
+	lease.release()
+
+	pressure := acquireResponseBufferLease()
+	pressure.buffer.Write(bytes.Repeat([]byte{0xa5}, len(writer.Bytes())))
+	pressure.release()
+
+	gotBytes, ok := decoded.GetBinary("bytes")
+	require.True(t, ok)
+	require.Equal(t, []byte{1, 2, 3, 4}, gotBytes)
+	nestedValue, ok := decoded.Get("nested")
+	require.True(t, ok)
+	gotNested, ok := nestedValue.(*types.MapValue)
+	require.True(t, ok)
+	gotName, ok := gotNested.GetString("name")
+	require.True(t, ok)
+	require.Equal(t, "value", gotName)
+	arrayValue, ok := decoded.Get("array")
+	require.True(t, ok)
+	gotArray, ok := arrayValue.([]types.FieldValue)
+	require.True(t, ok)
+	require.Equal(t, "one", gotArray[0])
+	require.Equal(t, []byte{5, 6, 7}, gotArray[1])
+}
+
+func TestResponseLeaseDropsLargeBuffer(t *testing.T) {
+	body := bytes.Repeat([]byte("x"), maxPooledResponseBufferCapacity+1)
+	lease, err := readHTTPResponseBodyLease(&http.Response{Body: io.NopCloser(bytes.NewReader(body))})
+	require.NoError(t, err)
+	buffer := lease.buffer
+	require.True(t, buffer.Cap() > maxPooledResponseBufferCapacity)
+	lease.release()
+	require.Nil(t, lease.buffer)
+}

--- a/nosqldb/types/values.go
+++ b/nosqldb/types/values.go
@@ -242,10 +242,19 @@ func NewMapValueFromJSON(jsonStr string) (*MapValue, error) {
 // An ordered MapValue guarantees that key/value pairs can be retrieved over the
 // GetByIndex(i int) method by specifying the insertion order.
 func NewOrderedMapValue() *MapValue {
+	return NewOrderedMapValueWithCapacity(16)
+}
+
+// NewOrderedMapValueWithCapacity creates an ordered MapValue with capacity for
+// the specified number of entries. A negative capacity is treated as zero.
+func NewOrderedMapValueWithCapacity(capacity int) *MapValue {
+	if capacity < 0 {
+		capacity = 0
+	}
 	return &MapValue{
-		m:                  make(map[string]interface{}),
+		m:                  make(map[string]interface{}, capacity),
 		keepInsertionOrder: true,
-		keys:               make([]string, 0, 16),
+		keys:               make([]string, 0, capacity),
 	}
 }
 

--- a/nosqldb/types/values_test.go
+++ b/nosqldb/types/values_test.go
@@ -29,6 +29,21 @@ func (suite *MapValueTestSuite) TestNewOrderedMapValue() {
 	suite.doMapValueTest(true)
 }
 
+func (suite *MapValueTestSuite) TestNewOrderedMapValueWithCapacity() {
+	m := NewOrderedMapValueWithCapacity(3)
+	suite.True(m.IsOrdered())
+	suite.Equal(0, m.Len())
+	suite.Equal(3, cap(m.keys))
+
+	m.Put("a", 1).Put("b", 2).Put("c", 3)
+	suite.Equal([]string{"a", "b", "c"}, m.keys)
+	suite.Equal(3, m.Len())
+
+	m = NewOrderedMapValueWithCapacity(-1)
+	suite.True(m.IsOrdered())
+	suite.Equal(0, cap(m.keys))
+}
+
 // TestNewMapValueFromJSON tests the NewMapValueFromJSON() function that
 // creates an unordered MapValue from the specified JSON.
 func (suite *MapValueTestSuite) TestNewMapValueFromJSON() {


### PR DESCRIPTION
## Summary

- add UTF-8 fast paths for binary string encoding and decoding while preserving malformed-input behavior
- preallocate ordered maps and publish immutable topology snapshots
- pool request writers through an explicit reference-counted body lease that survives retries, replay, and asynchronous transport closure
- preserve the `io.WriterTo` HTTP fast path and reject reads after body closure
- pool response buffers and binary readers with bounded retention and alias-safety tests

This addresses the request/response allocation pressure discussed in #50 and supersedes the unsafe request-buffer lifetime approach in #51.

## Safety

- request leases cannot be resurrected after final release
- owner and body releases are independently idempotent
- `Read`, `Close`, `GetBody`, content length, replay, and delayed transport closure have deterministic concurrency coverage
- malformed UTF-8 behavior is compared against the original implementation with fuzz tests
- decoded binary, nested map, and array values do not alias recycled response buffers
- topology snapshots are immutable after publication and preserve duplicate/nil equality semantics

## Validation

- `go test -modfile=/tmp/nosql-sdk-test.mod -count=1 ./...`
- changed-package `go vet` and full `go build ./...`
- focused `-race` coverage for client, HTTP, binary protocol, and value packages on the complete stack
- 30-second reader/writer compatibility fuzz runs: 551,086 and 192,541 executions

Identical-harness median microbenchmarks against `c3ac733`:

| Hot path | Time | Bytes/op | Allocs/op |
|---|---:|---:|---:|
| Read string | -49.0% | 424 to 328 | 5 to 4 |
| Read map | -32.2% | 2,168 to 1,672 | 44 to 43 |
| Write string | -79.7% | unchanged | unchanged |
| Write map | -29.8% | unchanged | unchanged |

The complete two-PR stack was also exercised on a three-server/two-client KVStore deployment with 200 total workers, one million 1 KiB rows, and a 50/50 Get/Put workload. The balanced A-B-B-A comparison improved mean throughput by 17.08%, reduced runtime allocations/op by 4.00%, and reduced GC cycles per million operations by 13.65%, with zero candidate errors and retries.

## Notes

Full-repository vet has two pre-existing findings in `nosqldb/common/ratelimit_test.go`; both reproduce at the pinned baseline. Long-duration cloud rate-limiter churn is outside this PR's validation scope.
