### PR TITLE
feat: bound HTTP resources and client background lifecycle

### DIFF
--- a/nosqldb/client.go
+++ b/nosqldb/client.go
@@ -1461,7 +1461,7 @@ func (c *Client) doExecuteWithLease(ctx context.Context, req Request, lease *req
 			continue
 		}
 
-		responseLease, readErr := readHTTPResponseBodyLease(httpResp)
+		responseLease, readErr := readHTTPResponseBodyLease(httpResp, c.MaxResponseSize)
 		lastRequestLatency = time.Since(requestStart)
 		responseData := responseLease.bytes()
 		lastResponseSize = len(responseData)
@@ -1879,7 +1879,7 @@ func (c *Client) processResponse(data []byte, httpResp *http.Response, req Reque
 }
 
 func readHTTPResponseBody(httpResp *http.Response) ([]byte, error) {
-	lease, err := readHTTPResponseBodyLease(httpResp)
+	lease, err := readHTTPResponseBodyLease(httpResp, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/nosqldb/client.go
+++ b/nosqldb/client.go
@@ -58,6 +58,9 @@ type Client struct {
 	// closeState ensures client resources are released at most once.
 	closeState uint32
 
+	closeIdleConnections func()
+	ownsHTTPTransport    bool
+
 	// requestURL represents the server URL that is the target of all client requests.
 	requestURL string
 
@@ -155,21 +158,26 @@ func NewClient(cfg Config) (*Client, error) {
 		if err != nil {
 			return nil, err
 		}
+		cfg.ownsHTTPClient = true
 	}
 
 	c := &Client{
-		Config:        cfg,
-		HTTPClient:    cfg.httpClient,
-		requestURL:    cfg.Endpoint + sdkutil.DataServiceURI,
-		requestID:     0,
-		serverHost:    cfg.host,
-		executor:      cfg.httpClient,
-		logger:        cfg.Logger,
-		statsControl:  newStatsControl(cfg),
-		isCloud:       cfg.IsCloud() || cfg.IsCloudSim(),
-		serialVersion: proto.DefaultSerialVersion,
-		queryVersion:  proto.DefaultQueryVersion,
-		topology:      nil,
+		Config:            cfg,
+		HTTPClient:        cfg.httpClient,
+		requestURL:        cfg.Endpoint + sdkutil.DataServiceURI,
+		requestID:         0,
+		serverHost:        cfg.host,
+		executor:          cfg.httpClient,
+		logger:            cfg.Logger,
+		statsControl:      newStatsControl(cfg),
+		isCloud:           cfg.IsCloud() || cfg.IsCloudSim(),
+		serialVersion:     proto.DefaultSerialVersion,
+		queryVersion:      proto.DefaultQueryVersion,
+		topology:          nil,
+		ownsHTTPTransport: cfg.ownsHTTPClient,
+	}
+	if c.ownsHTTPTransport {
+		c.closeIdleConnections = cfg.httpClient.CloseIdleConnections
 	}
 	c.handleResponse = c.processResponse
 	c.queryLogger, err = newQueryLogger()
@@ -210,6 +218,10 @@ func (c *Client) Close() error {
 
 	if c.queryLogger != nil {
 		c.queryLogger.Close()
+	}
+
+	if c.closeIdleConnections != nil {
+		c.closeIdleConnections()
 	}
 
 	// do not close logger; it may have been passed to us and
@@ -1189,6 +1201,7 @@ func (c *Client) doExecuteWithLease(ctx context.Context, req Request, lease *req
 
 	for {
 
+		attemptCause := err
 		if err != nil {
 			isSecErr := nosqlerr.IsSecurityInfoUnavailable(err)
 			isAuthRetry := isStatsAuthRetry(err)
@@ -1445,7 +1458,7 @@ func (c *Client) doExecuteWithLease(ctx context.Context, req Request, lease *req
 			}
 		}
 
-		reqCtx, reqCancel, deadlineErr := contextWithRemainingTimeout(reqTimeout, err)
+		reqCtx, reqCancel, deadlineErr := contextWithRemainingTimeout(reqTimeout, attemptCause)
 		if deadlineErr != nil {
 			httpReq.Body.Close()
 			observeError()

--- a/nosqldb/client.go
+++ b/nosqldb/client.go
@@ -35,6 +35,14 @@ import (
 
 const rateLimitDelayHeader = "X-Nosql-RL-Delay-Ms"
 
+type tableLimiterEntry struct {
+	// Keep first to guarantee 64-bit alignment on 32-bit systems.
+	lastAccessUnixNano int64
+	limiters           common.RateLimiterPair
+	hasLimiters        bool
+	nextRefresh        time.Time
+}
+
 // Client represents an Oracle NoSQL database client used to access the Oracle
 // NoSQL database cloud service or on-premise Oracle NoSQL database servers.
 type Client struct {
@@ -84,12 +92,16 @@ type Client struct {
 	// cloud simulator.
 	isCloud bool
 
-	// Internal rate limiting: cloud only
-	rateLimiterMap map[string]common.RateLimiterPair
+	// Internal rate limiting: cloud only.
+	rateLimiterMap map[string]*tableLimiterEntry
+	limitMux       sync.RWMutex
 
-	// Keep an internal map of tablename to next limits update time
-	tableLimitUpdateMap map[string]int64
-	limitMux            sync.RWMutex
+	bgMu                   sync.Mutex
+	bgWG                   sync.WaitGroup
+	bgCtx                  context.Context
+	bgCancel               context.CancelFunc
+	bgClosing              bool
+	limiterMaintenanceOnce sync.Once
 
 	// (possibly negotiated) version of the protocol in use
 	serialVersion int16
@@ -136,7 +148,9 @@ var (
 
 const (
 	// LimiterRefreshNanos is used to update table limits once every 10 minutes
-	LimiterRefreshNanos int64 = 600 * 1000 * 1000 * 1000
+	LimiterRefreshNanos    int64 = 600 * 1000 * 1000 * 1000
+	limiterCleanupInterval       = time.Hour
+	limiterInactiveTTL           = 24 * time.Hour
 	// SessionCookieField is used to check for persistent session cookies
 	SessionCookieField string = "session="
 )
@@ -161,6 +175,7 @@ func NewClient(cfg Config) (*Client, error) {
 		cfg.ownsHTTPClient = true
 	}
 
+	bgCtx, bgCancel := context.WithCancel(context.Background())
 	c := &Client{
 		Config:            cfg,
 		HTTPClient:        cfg.httpClient,
@@ -174,6 +189,8 @@ func NewClient(cfg Config) (*Client, error) {
 		serialVersion:     proto.DefaultSerialVersion,
 		queryVersion:      proto.DefaultQueryVersion,
 		topology:          nil,
+		bgCtx:             bgCtx,
+		bgCancel:          bgCancel,
 		ownsHTTPTransport: cfg.ownsHTTPClient,
 	}
 	if c.ownsHTTPTransport {
@@ -186,8 +203,8 @@ func NewClient(cfg Config) (*Client, error) {
 	}
 
 	if c.isCloud && cfg.RateLimitingEnabled {
-		c.tableLimitUpdateMap = make(map[string]int64)
-		c.rateLimiterMap = make(map[string]common.RateLimiterPair)
+		c.rateLimiterMap = make(map[string]*tableLimiterEntry)
+		c.startLimiterMaintenance()
 	}
 
 	c.oneTimeMessages = make(map[string]struct{})
@@ -207,6 +224,14 @@ func (c *Client) Close() error {
 	if !atomic.CompareAndSwapUint32(&c.closeState, 0, 1) {
 		return nil
 	}
+
+	c.bgMu.Lock()
+	c.bgClosing = true
+	if c.bgCancel != nil {
+		c.bgCancel()
+	}
+	c.bgMu.Unlock()
+	c.bgWG.Wait()
 
 	if c.statsControl != nil {
 		c.statsControl.shutdown()
@@ -1571,43 +1596,51 @@ func (c *Client) warmupClientAuth() {
 	c.logger.Fine("Auth warmed up successfully")
 }
 
-func (c *Client) tableNeedsRefreshLocked(tableName string) bool {
-	if c.tableLimitUpdateMap == nil {
-		return false
+func (c *Client) limiterEntryLocked(tableName string, now time.Time) *tableLimiterEntry {
+	entry := c.rateLimiterMap[tableName]
+	if entry == nil {
+		entry = &tableLimiterEntry{lastAccessUnixNano: now.UnixNano()}
+		c.rateLimiterMap[tableName] = entry
 	}
-
-	nowNanos := time.Now().UnixNano()
-	then := c.tableLimitUpdateMap[tableName]
-	return then <= nowNanos
+	return entry
 }
 
-func (c *Client) setTableNeedsRefreshLocked(tableName string, needsRefresh bool) {
-	if c.tableLimitUpdateMap == nil {
+func (c *Client) tableNeedsRefreshLocked(tableName string, now time.Time) bool {
+	if c.rateLimiterMap == nil {
+		return false
+	}
+	entry := c.rateLimiterMap[tableName]
+	return entry == nil || !now.Before(entry.nextRefresh)
+}
+
+func (c *Client) setTableNeedsRefreshLocked(tableName string, needsRefresh bool, now time.Time) {
+	if c.rateLimiterMap == nil {
 		return
 	}
-
-	lTable := strings.ToLower(tableName)
-	nowNanos := time.Now().UnixNano()
+	entry := c.limiterEntryLocked(strings.ToLower(tableName), now)
+	atomic.StoreInt64(&entry.lastAccessUnixNano, now.UnixNano())
 	if needsRefresh {
-		c.tableLimitUpdateMap[lTable] = nowNanos - 1
+		entry.nextRefresh = now.Add(-time.Nanosecond)
 	} else {
-		c.tableLimitUpdateMap[lTable] = nowNanos + LimiterRefreshNanos
+		entry.nextRefresh = now.Add(time.Duration(LimiterRefreshNanos))
 	}
 }
 
 func (c *Client) backgroundUpdateLimiters(tableName string) {
 	lTable := strings.ToLower(tableName)
-
+	now := time.Now()
 	c.limitMux.Lock()
-
-	if !c.tableNeedsRefreshLocked(lTable) {
+	if !c.tableNeedsRefreshLocked(lTable, now) {
+		if entry := c.rateLimiterMap[lTable]; entry != nil {
+			atomic.StoreInt64(&entry.lastAccessUnixNano, now.UnixNano())
+		}
 		c.limitMux.Unlock()
 		return
 	}
-	c.setTableNeedsRefreshLocked(lTable, false)
+	c.setTableNeedsRefreshLocked(lTable, false, now)
 	c.limitMux.Unlock()
 
-	go c.updateTableLimiters(lTable)
+	c.startBackground(func(ctx context.Context) { c.updateTableLimiters(ctx, lTable) })
 }
 
 func (c *Client) rateLimitingEnabled() bool {
@@ -1619,22 +1652,80 @@ func (c *Client) rateLimitingEnabled() bool {
 func (c *Client) getRateLimiterPair(tableName string) (common.RateLimiterPair, bool, bool) {
 	c.limitMux.RLock()
 	defer c.limitMux.RUnlock()
-
 	if c.rateLimiterMap == nil {
 		return common.RateLimiterPair{}, false, false
 	}
-
-	rp, ok := c.rateLimiterMap[strings.ToLower(tableName)]
-	return rp, ok, true
+	entry, ok := c.rateLimiterMap[strings.ToLower(tableName)]
+	if !ok {
+		return common.RateLimiterPair{}, false, true
+	}
+	atomic.StoreInt64(&entry.lastAccessUnixNano, time.Now().UnixNano())
+	if !entry.hasLimiters {
+		return common.RateLimiterPair{}, false, true
+	}
+	return entry.limiters, true, true
 }
 
 func (c *Client) setTableLimitRefreshTime(tableName string, refreshTimeNanos int64) {
 	c.limitMux.Lock()
 	defer c.limitMux.Unlock()
-
-	if c.tableLimitUpdateMap != nil {
-		c.tableLimitUpdateMap[strings.ToLower(tableName)] = refreshTimeNanos
+	if c.rateLimiterMap == nil {
+		return
 	}
+	now := time.Now()
+	entry := c.limiterEntryLocked(strings.ToLower(tableName), now)
+	atomic.StoreInt64(&entry.lastAccessUnixNano, now.UnixNano())
+	entry.nextRefresh = time.Unix(0, refreshTimeNanos)
+}
+
+func (c *Client) startBackground(fn func(context.Context)) bool {
+	c.bgMu.Lock()
+	if c.bgClosing {
+		c.bgMu.Unlock()
+		return false
+	}
+	c.bgWG.Add(1)
+	ctx := c.bgCtx
+	c.bgMu.Unlock()
+
+	go func() {
+		defer c.bgWG.Done()
+		fn(ctx)
+	}()
+	return true
+}
+
+func (c *Client) startLimiterMaintenance() {
+	c.limiterMaintenanceOnce.Do(func() {
+		c.startBackground(c.runLimiterMaintenance)
+	})
+}
+
+func (c *Client) runLimiterMaintenance(ctx context.Context) {
+	ticker := time.NewTicker(limiterCleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case now := <-ticker.C:
+			c.cleanupRateLimitersAt(now)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (c *Client) cleanupRateLimitersAt(now time.Time) int {
+	cutoff := now.Add(-limiterInactiveTTL).UnixNano()
+	removed := 0
+	c.limitMux.Lock()
+	defer c.limitMux.Unlock()
+	for tableName, entry := range c.rateLimiterMap {
+		if atomic.LoadInt64(&entry.lastAccessUnixNano) <= cutoff {
+			delete(c.rateLimiterMap, tableName)
+			removed++
+		}
+	}
+	return removed
 }
 
 // Comsume rate limiter units after successful operation.
@@ -1666,76 +1757,68 @@ func (c *Client) consumeLimiterUnitsWithContext(ctx context.Context, rl common.R
 
 func (c *Client) updateRateLimiters(tableName string, limits TableLimits) bool {
 	lTable := strings.ToLower(tableName)
-
+	now := time.Now()
 	c.limitMux.Lock()
 	defer c.limitMux.Unlock()
-
 	if c.rateLimiterMap == nil {
 		return false
 	}
 
-	c.setTableNeedsRefreshLocked(lTable, false)
-
+	entry := c.limiterEntryLocked(lTable, now)
+	atomic.StoreInt64(&entry.lastAccessUnixNano, now.UnixNano())
+	entry.nextRefresh = now.Add(time.Duration(LimiterRefreshNanos))
 	if limits.ReadUnits <= 0 && limits.WriteUnits <= 0 {
-		delete(c.rateLimiterMap, lTable)
+		entry.limiters = common.RateLimiterPair{}
+		entry.hasLimiters = false
 		c.logger.Fine("removing client-side rate limiting from table " + tableName)
 		return false
 	}
 
-	// Adjust units based on configured rate limiter percentage
-	RUs := float64(limits.ReadUnits)
-	WUs := float64(limits.WriteUnits)
+	readUnits := float64(limits.ReadUnits)
+	writeUnits := float64(limits.WriteUnits)
 	if c.RateLimiterPercentage > 0.0 {
-		RUs = (RUs * c.RateLimiterPercentage) / 100.0
-		WUs = (WUs * c.RateLimiterPercentage) / 100.0
+		readUnits = (readUnits * c.RateLimiterPercentage) / 100.0
+		writeUnits = (writeUnits * c.RateLimiterPercentage) / 100.0
 	}
-
-	// Create or update rate limiters in map
-	rp, ok := c.rateLimiterMap[lTable]
-	if ok {
-		rp.ReadLimiter.SetLimitPerSecond(RUs)
-		rp.WriteLimiter.SetLimitPerSecond(WUs)
+	if entry.hasLimiters {
+		entry.limiters.ReadLimiter.SetLimitPerSecond(readUnits)
+		entry.limiters.WriteLimiter.SetLimitPerSecond(writeUnits)
 	} else {
-		// Note: noSQL cloud service has a "burst" availability of
-		// 300 seconds. But we don't know if or how many other clients
-		// may have been using this table, and a duration of 30 seconds
-		// allows for more predictable usage.
-		c.rateLimiterMap[lTable] = common.RateLimiterPair{
-			ReadLimiter:  common.NewSimpleRateLimiterWithDuration(RUs, 30),
-			WriteLimiter: common.NewSimpleRateLimiterWithDuration(WUs, 30),
+		entry.limiters = common.RateLimiterPair{
+			ReadLimiter:  common.NewSimpleRateLimiterWithDuration(readUnits, 30),
+			WriteLimiter: common.NewSimpleRateLimiterWithDuration(writeUnits, 30),
 		}
+		entry.hasLimiters = true
 	}
 
-	c.logger.Fine("Updated table '%s' rate limiters to have RUs=%.1f and WUs=%.1f per second",
-		tableName, RUs, WUs)
-
+	c.logger.Fine("Updated table %q rate limiters to have RUs=%.1f and WUs=%.1f per second",
+		tableName, readUnits, writeUnits)
 	return true
 }
 
-func (c *Client) updateTableLimiters(tableName string) {
-	req := &GetTableRequest{
-		TableName: tableName,
-		Timeout:   5000 * time.Millisecond,
-	}
-	c.logger.Info("Starting GetTableRequest for table '%s'", tableName)
-	res, err := c.GetTable(req)
+func (c *Client) updateTableLimiters(ctx context.Context, tableName string) {
+	req := &GetTableRequest{TableName: tableName, Timeout: 5 * time.Second}
+	c.logger.Info("Starting GetTableRequest for table %q", tableName)
+	result, err := c.executeWithContext(ctx, req)
 	if err != nil {
-		c.logger.Info("GetTableRequest for table '%s' returned error: %v", tableName, err)
-		// allow retry after 100ms
-		c.setTableLimitRefreshTime(tableName, time.Now().UnixNano()+(100*1000*1000))
+		c.logger.Info("GetTableRequest for table %q returned error: %v", tableName, err)
+		if ctx.Err() == nil {
+			c.setTableLimitRefreshTime(tableName, time.Now().Add(100*time.Millisecond).UnixNano())
+		}
 		return
 	}
-	if res == nil {
-		c.logger.Info("GetTableRequest for table '%s' returned nil", tableName)
-		// allow retry after 100ms
-		c.setTableLimitRefreshTime(tableName, time.Now().UnixNano()+(100*1000*1000))
+	res, ok := result.(*TableResult)
+	if !ok || res == nil {
+		c.logger.Info("GetTableRequest for table %q returned no table result", tableName)
+		if ctx.Err() == nil {
+			c.setTableLimitRefreshTime(tableName, time.Now().Add(100*time.Millisecond).UnixNano())
+		}
 		return
 	}
 
-	c.logger.Info("GetTableRequest completed for table '%s'", tableName)
-	// update/add rate limiters for table
+	c.logger.Info("GetTableRequest completed for table %q", tableName)
 	if c.updateRateLimiters(tableName, res.Limits) {
-		c.logger.Info("background goroutine added limiters for table '%s'", tableName)
+		c.logger.Info("background goroutine added limiters for table %q", tableName)
 	}
 }
 
@@ -2158,37 +2241,33 @@ func isRetryableError(err error) bool {
 // RateLimitingEnabled to true in the client Config to enable rate limiting.
 func (c *Client) EnableRateLimiting(enable bool, usePercent float64) {
 	c.limitMux.Lock()
-	defer c.limitMux.Unlock()
-
 	c.RateLimiterPercentage = usePercent
 	if enable {
-		if c.rateLimiterMap != nil {
-			return
+		if c.rateLimiterMap == nil {
+			c.rateLimiterMap = make(map[string]*tableLimiterEntry)
 		}
-		c.rateLimiterMap = make(map[string]common.RateLimiterPair)
-		c.tableLimitUpdateMap = make(map[string]int64)
 	} else {
-		c.tableLimitUpdateMap = nil
 		c.rateLimiterMap = nil
 	}
+	c.limitMux.Unlock()
 }
 
-// ResetRateLimiters is for testing puposes only.
+// ResetRateLimiters is for testing purposes only.
 func (c *Client) ResetRateLimiters(tableName string) {
 	c.limitMux.RLock()
-	if c.rateLimiterMap == nil {
+	entry, ok := c.rateLimiterMap[strings.ToLower(tableName)]
+	if ok {
+		atomic.StoreInt64(&entry.lastAccessUnixNano, time.Now().UnixNano())
+	}
+	if !ok || !entry.hasLimiters {
 		c.limitMux.RUnlock()
 		return
 	}
-	rp, ok := c.rateLimiterMap[strings.ToLower(tableName)]
-	if !ok {
-		c.limitMux.RUnlock()
-		return
-	}
+	limiters := entry.limiters
 	c.limitMux.RUnlock()
 
-	rp.WriteLimiter.Reset()
-	rp.ReadLimiter.Reset()
+	limiters.WriteLimiter.Reset()
+	limiters.ReadLimiter.Reset()
 }
 
 // VerifyConnection attempts to verify that the connection is useable.

--- a/nosqldb/client_test.go
+++ b/nosqldb/client_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/oracle/nosql-go-sdk/nosqldb/common"
+	"github.com/oracle/nosql-go-sdk/nosqldb/httputil"
 	"github.com/oracle/nosql-go-sdk/nosqldb/internal/proto/binary"
 	"github.com/oracle/nosql-go-sdk/nosqldb/nosqlerr"
 	"github.com/oracle/nosql-go-sdk/nosqldb/types"
@@ -670,6 +671,31 @@ func TestTopologyInfoIsCloned(t *testing.T) {
 	ti = client.getTopologyInfo()
 	require.NotNil(t, ti)
 	require.Equal(t, []int{1, 2, 3}, ti.ShardIDs)
+}
+
+func TestClientHTTPTransportOwnership(t *testing.T) {
+	owned, err := newMockClient()
+	require.NoError(t, err)
+	require.True(t, owned.ownsHTTPTransport)
+	require.NotNil(t, owned.closeIdleConnections)
+	closeCalls := 0
+	owned.closeIdleConnections = func() { closeCalls++ }
+	require.NoError(t, owned.Close())
+	require.NoError(t, owned.Close())
+	require.Equal(t, 1, closeCalls)
+
+	sharedHTTP, err := httputil.NewHTTPClient(httputil.HTTPConfig{})
+	require.NoError(t, err)
+	shared, err := NewClient(Config{
+		Mode:                  "onprem",
+		Endpoint:              "localhost:8080",
+		AuthorizationProvider: &DummyAccessTokenProvider{TenantID: "test"},
+		httpClient:            sharedHTTP,
+	})
+	require.NoError(t, err)
+	require.False(t, shared.ownsHTTPTransport)
+	require.Nil(t, shared.closeIdleConnections)
+	require.NoError(t, shared.Close())
 }
 
 func TestTopologySnapshotRemainsImmutable(t *testing.T) {

--- a/nosqldb/client_test.go
+++ b/nosqldb/client_test.go
@@ -912,3 +912,104 @@ func (e *deadlineRecordingExecutor) Do(req *http.Request) (*http.Response, error
 		Err: mockErr{msg: "non-retryable error"},
 	}
 }
+
+type contextBlockingExecutor struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+func (e *contextBlockingExecutor) Do(req *http.Request) (*http.Response, error) {
+	e.once.Do(func() { close(e.started) })
+	<-req.Context().Done()
+	return nil, req.Context().Err()
+}
+
+func TestLimiterCleanupRetainsRecentlyAccessedEntry(t *testing.T) {
+	client, err := NewClient(Config{
+		Mode:                "cloudsim",
+		Endpoint:            "localhost:8080",
+		RateLimitingEnabled: true,
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	now := time.Now()
+	old := &tableLimiterEntry{lastAccessUnixNano: now.Add(-limiterInactiveTTL - time.Hour).UnixNano()}
+	recent := &tableLimiterEntry{lastAccessUnixNano: now.Add(-time.Minute).UnixNano()}
+	client.limitMux.Lock()
+	client.rateLimiterMap["old"] = old
+	client.rateLimiterMap["recent"] = recent
+	client.limitMux.Unlock()
+
+	require.Equal(t, 1, client.cleanupRateLimitersAt(now))
+	client.limitMux.RLock()
+	_, oldExists := client.rateLimiterMap["old"]
+	_, recentExists := client.rateLimiterMap["recent"]
+	client.limitMux.RUnlock()
+	require.False(t, oldExists)
+	require.True(t, recentExists)
+
+	atomic.StoreInt64(&recent.lastAccessUnixNano, now.Add(-limiterInactiveTTL-time.Hour).UnixNano())
+	_, _, _ = client.getRateLimiterPair("recent")
+	require.Equal(t, 0, client.cleanupRateLimitersAt(now))
+}
+
+func TestCloseCancelsAndWaitsForLimiterRefresh(t *testing.T) {
+	client, err := NewClient(Config{
+		Mode:                "cloudsim",
+		Endpoint:            "localhost:8080",
+		RateLimitingEnabled: true,
+	})
+	require.NoError(t, err)
+	executor := &contextBlockingExecutor{started: make(chan struct{})}
+	client.executor = executor
+	client.backgroundUpdateLimiters("table")
+
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("limiter refresh did not start")
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		_ = client.Close()
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not wait for and cancel limiter refresh")
+	}
+	require.False(t, client.startBackground(func(context.Context) {}))
+	require.NoError(t, client.Close())
+}
+
+func TestStartBackgroundRacesWithClose(t *testing.T) {
+	client, err := newMockClient()
+	require.NoError(t, err)
+
+	start := make(chan struct{})
+	var schedulers sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		schedulers.Add(1)
+		go func() {
+			defer schedulers.Done()
+			<-start
+			client.startBackground(func(ctx context.Context) { <-ctx.Done() })
+		}()
+	}
+	close(start)
+
+	closed := make(chan struct{})
+	go func() {
+		_ = client.Close()
+		close(closed)
+	}()
+	schedulers.Wait()
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("Close deadlocked while background work was being scheduled")
+	}
+}

--- a/nosqldb/config.go
+++ b/nosqldb/config.go
@@ -102,6 +102,10 @@ type Config struct {
 	// Configurations for HTTP client.
 	httputil.HTTPConfig `json:"httpConfig,omitempty"`
 
+	// MaxResponseSize limits bytes read from the response body presented by net/http.
+	// Zero and math.MaxInt64 are effectively unlimited.
+	MaxResponseSize int64 `json:"maxResponseSize,omitempty"`
+
 	// Configurations for logging.
 	LoggingConfig `json:"loggingConfig,omitempty"`
 
@@ -184,6 +188,10 @@ func (c *Config) validate() error {
 
 	if len(c.Endpoint) > 0 && len(c.Region) > 0 {
 		return fmt.Errorf("cannot have both Endpoint and Region specified")
+	}
+
+	if c.MaxResponseSize < 0 {
+		return fmt.Errorf("max response size must not be negative")
 	}
 
 	if err := c.validateStatsConfig(); err != nil {

--- a/nosqldb/config.go
+++ b/nosqldb/config.go
@@ -171,7 +171,8 @@ type Config struct {
 	port     string
 	protocol string
 
-	httpClient *httputil.HTTPClient
+	httpClient     *httputil.HTTPClient
+	ownsHTTPClient bool
 }
 
 func (c *Config) validate() error {
@@ -254,6 +255,7 @@ func (c *Config) setDefaults() (err error) {
 		// is not required.
 		if c.AuthorizationProvider == nil && len(c.Username) > 0 && len(c.Password) > 0 {
 			c.httpClient, err = httputil.NewHTTPClient(c.HTTPConfig)
+			c.ownsHTTPClient = err == nil
 			if err != nil {
 				return err
 			}
@@ -279,6 +281,7 @@ func (c *Config) setDefaults() (err error) {
 			if atp.GetHTTPClient() == nil {
 				if c.httpClient == nil {
 					c.httpClient, err = httputil.NewHTTPClient(c.HTTPConfig)
+					c.ownsHTTPClient = err == nil
 					if err != nil {
 						return err
 					}

--- a/nosqldb/httputil/httpclient.go
+++ b/nosqldb/httputil/httpclient.go
@@ -62,11 +62,18 @@ func NewHTTPClient(cfg HTTPConfig) (*HTTPClient, error) {
 		}
 	}
 
+	if cfg.MaxConnsPerHost < 0 {
+		return nil, fmt.Errorf("max connections per host must not be negative")
+	}
+
 	if cfg.MaxIdleConns != 0 {
 		tr.MaxIdleConns = cfg.MaxIdleConns
 	}
 	if cfg.MaxIdleConnsPerHost != 0 {
 		tr.MaxIdleConnsPerHost = cfg.MaxIdleConnsPerHost
+	}
+	if cfg.MaxConnsPerHost > 0 {
+		tr.MaxConnsPerHost = cfg.MaxConnsPerHost
 	}
 	if cfg.IdleConnTimeout != 0 {
 		tr.IdleConnTimeout = cfg.IdleConnTimeout
@@ -115,6 +122,14 @@ func (hc *HTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return hc.client.Do(req)
 }
 
+// CloseIdleConnections closes connections that are idle in the transport.
+// It does not interrupt active requests.
+func (hc *HTTPClient) CloseIdleConnections() {
+	if hc != nil && hc.client != nil {
+		hc.client.CloseIdleConnections()
+	}
+}
+
 // DefaultHTTPClient is a default HTTPClient instance that is ready to use.
 var DefaultHTTPClient = &HTTPClient{
 	client: http.DefaultClient,
@@ -153,6 +168,9 @@ type HTTPConfig struct {
 	// to keep per-host.
 	// The default value is 100.
 	MaxIdleConnsPerHost int `json:"maxIdleConnsPerHost,omitempty"`
+
+	// MaxConnsPerHost limits total connections per host. Zero is unlimited.
+	MaxConnsPerHost int `json:"maxConnsPerHost,omitempty"`
 
 	// IdleConnTimeout is the maximum amount of time an idle (keep-alive)
 	// connection will remain idle before closing itself.

--- a/nosqldb/httputil/httpclient_test.go
+++ b/nosqldb/httputil/httpclient_test.go
@@ -1,3 +1,10 @@
+//
+// Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+//
+// Licensed under the Universal Permissive License v 1.0 as shown at
+//  https://oss.oracle.com/licenses/upl/
+//
+
 package httputil
 
 import (

--- a/nosqldb/httputil/httpclient_test.go
+++ b/nosqldb/httputil/httpclient_test.go
@@ -1,0 +1,49 @@
+package httputil
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxConnsPerHostConfiguration(t *testing.T) {
+	client, err := NewHTTPClient(HTTPConfig{MaxConnsPerHost: 256})
+	require.NoError(t, err)
+	transport, ok := client.client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.Equal(t, 256, transport.MaxConnsPerHost)
+
+	_, err = NewHTTPClient(HTTPConfig{MaxConnsPerHost: -1})
+	require.Error(t, err)
+}
+
+func TestCloseIdleConnectionsDoesNotInterruptActiveRequest(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-release
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(HTTPConfig{})
+	require.NoError(t, err)
+	result := make(chan error, 1)
+	go func() {
+		response, requestErr := client.client.Get(server.URL)
+		if requestErr == nil {
+			_, requestErr = io.ReadAll(response.Body)
+			response.Body.Close()
+		}
+		result <- requestErr
+	}()
+
+	<-started
+	client.CloseIdleConnections()
+	close(release)
+	require.NoError(t, <-result)
+}

--- a/nosqldb/response_lease.go
+++ b/nosqldb/response_lease.go
@@ -9,6 +9,10 @@ package nosqldb
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"math"
 	"net/http"
 	"sync"
 
@@ -17,7 +21,26 @@ import (
 
 const maxPooledResponseBufferCapacity = 64 * 1024
 
-var responseBufferPool = sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
+var (
+	responseBufferPool = sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
+	// ErrResponseSizeLimitExceeded identifies a response that exceeded MaxResponseSize.
+	ErrResponseSizeLimitExceeded = errors.New("response size limit exceeded")
+)
+
+// ResponseSizeLimitError reports an oversized response. Observed is a lower
+// bound when reading stopped after MaxResponseSize plus one byte.
+type ResponseSizeLimitError struct {
+	Limit    int64
+	Observed int64
+}
+
+func (e *ResponseSizeLimitError) Error() string {
+	return fmt.Sprintf("response size limit exceeded: limit=%d observed-at-least=%d", e.Limit, e.Observed)
+}
+
+func (e *ResponseSizeLimitError) Unwrap() error {
+	return ErrResponseSizeLimitExceeded
+}
 
 type responseBufferLease struct {
 	buffer *bytes.Buffer
@@ -52,7 +75,7 @@ func (l *responseBufferLease) release() {
 	})
 }
 
-func readHTTPResponseBodyLease(httpResp *http.Response) (*responseBufferLease, error) {
+func readHTTPResponseBodyLease(httpResp *http.Response, limit int64) (*responseBufferLease, error) {
 	if httpResp == nil {
 		return nil, nosqlerr.New(nosqlerr.UnknownError, "nil http response")
 	}
@@ -61,10 +84,24 @@ func readHTTPResponseBodyLease(httpResp *http.Response) (*responseBufferLease, e
 	}
 	defer httpResp.Body.Close()
 
+	unlimited := limit == 0 || limit == math.MaxInt64
+	if !unlimited && !httpResp.Uncompressed && httpResp.ContentLength > limit {
+		return nil, &ResponseSizeLimitError{Limit: limit, Observed: httpResp.ContentLength}
+	}
+
 	lease := acquireResponseBufferLease()
-	if _, err := lease.buffer.ReadFrom(httpResp.Body); err != nil {
+	reader := io.Reader(httpResp.Body)
+	if !unlimited {
+		reader = &io.LimitedReader{R: httpResp.Body, N: limit + 1}
+	}
+	if _, err := lease.buffer.ReadFrom(reader); err != nil {
 		lease.release()
 		return nil, err
+	}
+	if !unlimited && int64(lease.buffer.Len()) > limit {
+		observed := int64(lease.buffer.Len())
+		lease.release()
+		return nil, &ResponseSizeLimitError{Limit: limit, Observed: observed}
 	}
 	return lease, nil
 }

--- a/nosqldb/response_lease_test.go
+++ b/nosqldb/response_lease_test.go
@@ -9,7 +9,9 @@ package nosqldb
 
 import (
 	"bytes"
+	"errors"
 	"io"
+	"math"
 	"net/http"
 	"testing"
 
@@ -30,7 +32,7 @@ func (b *trackedResponseBody) Close() error {
 
 func TestResponseLeaseClosesBodyAndReleasesBuffer(t *testing.T) {
 	body := &trackedResponseBody{Reader: bytes.NewBufferString("response")}
-	lease, err := readHTTPResponseBodyLease(&http.Response{Body: body})
+	lease, err := readHTTPResponseBodyLease(&http.Response{Body: body}, 0)
 	require.NoError(t, err)
 	require.True(t, body.closed)
 	require.Equal(t, []byte("response"), lease.bytes())
@@ -50,7 +52,7 @@ func TestResponseValuesDoNotAliasPooledBuffer(t *testing.T) {
 	_, err := writer.WriteMap(value)
 	require.NoError(t, err)
 
-	lease, err := readHTTPResponseBodyLease(&http.Response{Body: io.NopCloser(bytes.NewReader(writer.Bytes()))})
+	lease, err := readHTTPResponseBodyLease(&http.Response{Body: io.NopCloser(bytes.NewReader(writer.Bytes()))}, 0)
 	require.NoError(t, err)
 	reader := binary.GetReader(bytes.NewBuffer(lease.bytes()))
 	decoded, err := reader.ReadMap()
@@ -82,10 +84,74 @@ func TestResponseValuesDoNotAliasPooledBuffer(t *testing.T) {
 
 func TestResponseLeaseDropsLargeBuffer(t *testing.T) {
 	body := bytes.Repeat([]byte("x"), maxPooledResponseBufferCapacity+1)
-	lease, err := readHTTPResponseBodyLease(&http.Response{Body: io.NopCloser(bytes.NewReader(body))})
+	lease, err := readHTTPResponseBodyLease(&http.Response{Body: io.NopCloser(bytes.NewReader(body))}, 0)
 	require.NoError(t, err)
 	buffer := lease.buffer
 	require.True(t, buffer.Cap() > maxPooledResponseBufferCapacity)
 	lease.release()
 	require.Nil(t, lease.buffer)
+}
+
+func TestResponseSizeLimit(t *testing.T) {
+	tests := []struct {
+		name          string
+		limit         int64
+		body          []byte
+		contentLength int64
+		uncompressed  bool
+		wantError     bool
+	}{
+		{"unlimited zero", 0, []byte("abcdef"), 6, false, false},
+		{"unlimited max int", math.MaxInt64, []byte("abcdef"), 6, false, false},
+		{"max int minus one", math.MaxInt64 - 1, []byte("abcdef"), 6, false, false},
+		{"exact limit", 6, []byte("abcdef"), 6, false, false},
+		{"known oversized", 5, []byte("abcdef"), 6, false, true},
+		{"unknown oversized", 5, []byte("abcdef"), -1, false, true},
+		{"decompressed oversized", 5, []byte("abcdef"), 3, true, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := &trackedResponseBody{Reader: bytes.NewReader(tc.body)}
+			lease, err := readHTTPResponseBodyLease(&http.Response{
+				Body:          body,
+				ContentLength: tc.contentLength,
+				Uncompressed:  tc.uncompressed,
+			}, tc.limit)
+			require.True(t, body.closed)
+			if !tc.wantError {
+				require.NoError(t, err)
+				require.Equal(t, tc.body, lease.bytes())
+				lease.release()
+				return
+			}
+
+			require.Error(t, err)
+			require.True(t, errors.Is(err, ErrResponseSizeLimitExceeded))
+			var sizeErr *ResponseSizeLimitError
+			require.True(t, errors.As(err, &sizeErr))
+			require.Equal(t, tc.limit, sizeErr.Limit)
+			require.True(t, sizeErr.Observed > tc.limit)
+			require.Nil(t, lease)
+		})
+	}
+}
+
+type failingResponseReader struct{}
+
+func (failingResponseReader) Read([]byte) (int, error) {
+	return 0, errors.New("read failure")
+}
+
+func TestResponseSizeLimitReadErrorClosesBody(t *testing.T) {
+	body := &trackedResponseBody{Reader: failingResponseReader{}}
+	lease, err := readHTTPResponseBodyLease(&http.Response{Body: body, ContentLength: -1}, 8)
+	require.Error(t, err)
+	require.True(t, body.closed)
+	require.Nil(t, lease)
+}
+
+func TestNegativeMaxResponseSizeRejected(t *testing.T) {
+	cfg := Config{MaxResponseSize: -1}
+	require.Error(t, cfg.validate())
 }


### PR DESCRIPTION
## Summary

- add an optional response-body size limit with default-unlimited compatibility
- handle known, unknown, and transparently decompressed response lengths without `limit + 1` overflow
- expose HTTP connection limits and close idle connections only for SDK-owned transports
- coordinate client-created limiter refresh and maintenance goroutines with cancellation and a wait group
- reject new background work once close starts and make repeated `Close` calls safe
- consolidate rate-limiter state and expire inactive entries using atomic access timestamps plus locked rechecks

This PR is stacked on `perf/issue-50-allocation-pooling` so lifecycle and reliability behavior can be reviewed separately from serialization and pooling.

## Safety

- oversized bodies are closed without an unbounded drain
- `errors.Is` and `errors.As` work for response-size failures
- active requests are not interrupted by idle-connection cleanup
- shared/user-supplied HTTP transports are not closed by the SDK
- refresh scheduling and `Close` races are covered, including cancellation of in-flight refresh requests
- cleanup reloads limiter access time under the map write lock before deletion

## Validation

- `go test -modfile=/tmp/nosql-sdk-test.mod -count=1 ./...`
- `go test -race -count=1 ./nosqldb ./nosqldb/httputil ./nosqldb/internal/proto/binary ./nosqldb/types`
- changed-package `go vet`
- full `go build ./...`
- 30-second malformed UTF-8 reader/writer compatibility fuzz runs

Five-VM validation used three KVStore servers and two client-side proxies/benchmark clients. The fresh-table workload used one million deterministic 1 KiB rows, 100 workers per client, normal `GOGC=100`, and 50/50 Get/Put operations.

| Sample | Revision | Combined ops/s | Errors | Retries |
|---|---|---:|---:|---:|
| A1 | Baseline `c3ac733` | 52,957.52 | 5 boundary cancellations | 0 |
| B1 | Candidate | 59,824.52 | 0 | 0 |
| B2 | Candidate | 61,180.49 | 0 | 0 |
| A2 | Baseline `c3ac733` | 50,390.95 | 14 boundary cancellations | 0 |

Candidate mean throughput was 60,502.50 ops/s versus 51,674.24 for baseline, a 17.08% improvement. Runtime allocations/op fell 4.00%, and GC cycles per million operations fell 13.65%. Candidate p99 latency was also lower in both crossover samples.

## Notes

The baseline failures had no SDK call and a one-microsecond recorded latency, identifying them as benchmark measurement-boundary cancellation rather than service errors. Multi-hour endurance and cloud rate-limiter churn remain follow-up validation items.
